### PR TITLE
Add ability to remove VISC logo from reports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R:
     person(given = "Marie",
            family = "Vendettuoli",
            role = c("aut"),
-           email = "mvendett@scharp.org")
+           email = "mvendett@fredhutch.org")
     person(given = "Monica",
            family = "Gerber",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,11 @@
 Package: VISCtemplates
 Title: Tools for writing reproducible reports at VISC
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
+    person(given = "Marie",
+           family = "Vendettuoli",
+           role = c("ctb"),
+           email = "mvendett@scharp.org")
     person(given = "Jimmy",
            family = "Fulp",
            role = c("aut", "cre"),
@@ -10,7 +14,7 @@ Authors@R:
            family = "Gerber",
            role = c("aut", "cre"),
            email = "mwgerber@gmail.com")
-Description: What the package does (one paragraph).
+Description: The goal of VISCtemplates is to automate project setup provide a common easy-to-understand directory structure across analyses, provide consistency across reports in the same project/protocol, and provide consistency across reports analyzing data from the same assay.
 License: GPL-3 + file LICENSE
 Depends: R (>= 3.0)
 Imports:
@@ -22,7 +26,7 @@ Encoding: UTF-8
 LazyData: true
 URL: https://github.com/FredHutch/VISCtemplates
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Suggests: 
     knitr
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,14 +2,14 @@ Package: VISCtemplates
 Title: Tools for writing reproducible reports at VISC
 Version: 0.1.0.9000
 Authors@R: 
-    person(given = "Marie",
-           family = "Vendettuoli",
-           role = c("ctb"),
-           email = "mvendett@scharp.org")
     person(given = "Jimmy",
            family = "Fulp",
            role = c("aut", "cre"),
            email = "wfulp@fredhutch.org")
+    person(given = "Marie",
+           family = "Vendettuoli",
+           role = c("aut"),
+           email = "mvendett@scharp.org")
     person(given = "Monica",
            family = "Gerber",
            role = c("aut", "cre"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 find_resource <- function(template, file = 'template.tex', package = "VISCtemplates") {
   res <- system.file(
-    "rmarkdown", "templates", template, "resources", file, package = "VISCtemplates"
+    "rmarkdown", "templates", template, "resources", file, package = package
   )
   if (res == "") stop(
     "Couldn't find template file ", template, "/resources/", file, call. = FALSE

--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -143,7 +143,10 @@
 \renewcommand{\headrulewidth}{0.8pt}
 \renewcommand{\footrulewidth}{0.8pt}
 \fancyhead[L]{\includegraphics[height=0.8cm]{$logo_path_scharp$}}
+$if(dropVISClogo)$
+$else$
 \fancyhead[C]{\includegraphics[height=0.8cm]{$logo_path_visc$}}
+$endif$
 \fancyhead[R]{\includegraphics[height=0.8cm]{$logo_path_fh$}}
 \fancyfoot[C]{Page \thepage{}~of~\pageref{LastPage}}
 \setlength{\headheight}{27pt}

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -27,6 +27,7 @@ bibliography: bibliography.bib
 lof: true
 lot: true
 toc: true
+dropVISClogo: false
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default

--- a/man/visc_word_document.Rd
+++ b/man/visc_word_document.Rd
@@ -4,8 +4,7 @@
 \alias{visc_word_document}
 \title{Convert to a VISC Report Word document}
 \usage{
-visc_word_document(toc = TRUE, fig_caption = TRUE, keep_md = TRUE,
-  ...)
+visc_word_document(toc = TRUE, fig_caption = TRUE, keep_md = TRUE, ...)
 }
 \arguments{
 \item{toc}{include table of contents}


### PR DESCRIPTION
Adding dropVISClogo param to be able to remove VISC logo from reports if desired, and updating description file.

Setting it to false as default so backwards compatible 