### PR TITLE
Feature/update readmes

### DIFF
--- a/inst/rmarkdown/templates/visc_report/skeleton/README.md
+++ b/inst/rmarkdown/templates/visc_report/skeleton/README.md
@@ -2,11 +2,11 @@
 
 | **Version** | **Date sent to VDC**| **Unblinded** | **Data Spec.**|**Lab Spec.** | **Commit link** |
 |------------------|-----------------|------------------|-----------------|------------------|-----------------|
-|1.0 | [insert date] | Yes/No |[data spec version no.](permanent link - see comments below) | [lab method spec no](permanent link - see comments below) | [hash](https://github.fhcrc.org/VIDD-VISC/...) |
+|1.0 | [insert date] | Yes/No |[data spec version no.](permanent link - see comments below) | [lab method spec no](permanent link - see comments below) | [hash](https://github.com/fredhutch/...) |
 
 If analysis uses assay spec. <1.0 or an alternative specification use “N/A”. If there is something worth noting about the methods or report versions, briefly describe that here as well.
 
-[](To find the appropriate commit hash and report link: when you're at the file on GitHub, click the history button -> then click the commit corresponding to the distributed report -> find the report among the edits and click View -> hash is in the url: https://github.fhcrc.org/VIDD-VISC/.../blob/hash/...)
+[](To find the appropriate commit hash and report link: when you're at the file on GitHub, click the history button -> then click the commit corresponding to the distributed report -> find the report among the edits and click View -> hash is in the url: https://github.com/fredhutch/.../blob/hash/...)
 
 [](To get permanent GitHub link for assay spec, use the preceding hash procedure in https://github.fhcrc.org/VIDD-VISC/Assay_Data_Specs/ to find the link.)
 
@@ -16,7 +16,7 @@ USE_AS_EXAMPLE_THEN_DELETE_ME
 
 | **Version** | **Date sent to VDC**| **Unblinded** | **Data Spec.**|**Lab Spec.** | **Commit link** |
 |------------------|-----------------|------------------|-----------------|------------------|-----------------|
-|1.0 | 2017-10-31 | Yes | [1.0](https://github.fhcrc.org/VIDD-VISC/Assay_Data_Specs/blob/b24a7638bb949ba8264deba02f030fbd6f857b9a/BAMA_Serum.md) | [1.0](https://github.fhcrc.org/VIDD-VISC/Assay_Data_Specs/blob/816ec28142f9c89a3dccb9f17d64476f1056f99f/Lab_Methods/BAMA_Lab_Methods.md)| [69bd4bc35cd24dabef4b3f97d9a96068f600891e](https://github.fhcrc.org/VIDD-VISC/Uberla465Analysis/blob/69bd4bc35cd24dabef4b3f97d9a96068f600891e/BAMA/Uberla465_BAMA_PT/Uberla465_BAMA_PT.pdf) |
+|1.0 | 2019-10-22 | Yes | [1.0](https://github.com/FredHutch/VISC-Assay-Methods/blob/dc48c4a719e577a313c22a2d97701d6a676595c5/Assay_Data_Specs/BAMA/serum_bama.md) | [3.0](https://github.com/FredHutch/VISC-Assay-Methods/blob/dc48c4a719e577a313c22a2d97701d6a676595c5/Lab_Methods/BAMA_Lab_Methods.md)| [afbc59bf0a9a532d5edf62d59985ba8ce2f8c1e8](https://github.com/FredHutch/McElrath749Analysis/blob/afbc59bf0a9a532d5edf62d59985ba8ce2f8c1e8/BAMA/BAMA_IgG_pt_report/BAMA_IgG_pt_report.pdf) |
 
 
 ## Analysis notes

--- a/inst/templates/visc-project-readme.Rmd
+++ b/inst/templates/visc-project-readme.Rmd
@@ -13,10 +13,7 @@ The data for the {{ study_name }} protocol can be found here: [insert path]. You
 
 ```{r install-example, eval=FALSE}
 # if on github:
-devtools::install_github(
-  repo = "FredHutch/reponame.git",
-  auth_token = Sys.getenv("GITHUB_KEY")
-)
+devtools::install_github(repo = "FredHutch/reponame.git")
 
 # if on network drives:
 devtools::install_git("path")


### PR DESCRIPTION
Some minor changes to README templates:

1) I changed the PT report README so that the examples use github.com/FredHutch links.
2) I changed the project-level README so that it uses "GITHUB_PAT". This is the default with `devtools::install_github()` (it looks for the authentication token assigned to the "GITHUB_PAT" variable).