### PR TITLE
Adding leftheader YAML param for ability customize left header in Reports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Encoding: UTF-8
 LazyData: true
 URL: https://github.com/FredHutch/VISCtemplates
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests: 
     knitr
 VignetteBuilder: knitr

--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -246,8 +246,11 @@ $endif$
 \newpage
 \fancyhead[R]{\em $shorttitle$}
 \fancyhead[C]{}
+$if(leftheader)$
+\fancyhead[L]{\em $leftheader$}
+$else$
 \fancyhead[L]{\em VISC Report}
-
+$endif$
 %\printglossaries
 
 $body$

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -1,6 +1,7 @@
 ---
 title: "Title of Your Submission"
 shorttitle: "Short Title"
+leftheader: "VISC Report"
 from:
  - name: FirstNameA LastNameA
    email: foo@bar.com


### PR DESCRIPTION
This change is to allow custom left headers instead of always saying "VISC Report".

If the parameter is left off YAML entirely or left blank then the left header will default to `VISC Report`.