### PR TITLE
Adding cslreferences environment in template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: VISCtemplates
 Title: Tools for writing reproducible reports at VISC
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     person(given = "Jimmy",
            family = "Fulp",
@@ -26,7 +26,7 @@ Encoding: UTF-8
 LazyData: true
 URL: https://github.com/FredHutch/VISCtemplates
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests: 
     knitr
 VignetteBuilder: knitr

--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -120,6 +120,16 @@
   citecolor  = gray  % color of citations
 }
 
+% pandoc now requires a cslreferences environment to be defined in the latex template
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
+
 
 %this is to adjust header and footer in landscaped pages
 \fancypagestyle{lscape}{%


### PR DESCRIPTION
Hotfix needed to address issue that came up with newer Pandoc versions:
https://github.com/rstudio/rmarkdown/issues/1649