### PR TITLE
Fix footnote hyperlink issue

### DIFF
--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -3,9 +3,7 @@
 \reserveinserts{28}
 \usepackage{lastpage}
 \usepackage[hmargin=2cm, top=2.7cm, bottom=3.5cm, footskip=0.5cm]{geometry}
-\usepackage{hyperref}
 \usepackage{url}
-\usepackage{float}
 \usepackage[maxfloats=50]{morefloats}
 \usepackage{parskip}
 \usepackage[citestyle=authoryear-comp,natbib=true]{biblatex}
@@ -27,6 +25,9 @@
 \usepackage{makecell}
 \usepackage{threeparttable}
 \usepackage{threeparttablex}
+\usepackage{hyperref}
+\usepackage{float}
+
 
 
 \bibliography{$bibliography$}


### PR DESCRIPTION
Closes #55 

Testing this on large report and everything working as expected. The footnote links to the bottom of the page now when using `^[MY_FOOTNOTE]` in the rmd report