### PR TITLE
Update README: vignette missing

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,8 @@ The package is available on the Fred Hutch organization GitHub page.
 remotes::install_github("FredHutch/VISCtemplates")
 
 # to access the vignette, use devtools:
-devtools::install_github("FredHutch/VISCtemplates", build_vignettes = TRUE)
+devtools::install_github("FredHutch/VISCtemplates",
+                         build_opts = c("--no-resave-data", "--no-manual"))
 ```
 
 ## Requirements

--- a/README.Rmd
+++ b/README.Rmd
@@ -34,9 +34,8 @@ The package is available on the Fred Hutch organization GitHub page.
 ```{r eval=FALSE}
 remotes::install_github("FredHutch/VISCtemplates")
 
-# to access the vignette, use devtools:
-devtools::install_github("FredHutch/VISCtemplates",
-                         build_opts = c("--no-resave-data", "--no-manual"))
+# to access the vignette, use set the `build_vignettes = TRUE`:
+remotes::install_github("FredHutch/VISCtemplates", build_vignettes = TRUE)
 ```
 
 ## Requirements


### PR DESCRIPTION
Instructions for including vignette are not correct.
``` r
devtools::install_github("FredHutch/VISCtemplates", build_vignettes = TRUE)
vignette("using_pdf_and_word_template")
#> Warning message:
#> vignette ‘using_pdf_and_word_template’ not found 
browseVignettes("VISCtemplates")
#> No vignettes found by browseVignettes("VISCtemplates")
```

To include the vignettes:
``` r
devtools::install_github("FredHutch/VISCtemplates", 
                                      build_opts = c("--no-resave-data", "--no-manual"))
vignette("using_pdf_and_word_template")
```