### PR TITLE
Switching to remotes in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The package is available on the Fred Hutch organization GitHub page.
 ``` r
 remotes::install_github("FredHutch/VISCtemplates")
 
-# to access the vignette, use devtools:
-devtools::install_github("FredHutch/VISCtemplates", build_vignettes = TRUE)
+# Use the build_vignettes parameter to access the vignette:
+remotes::install_github("FredHutch/VISCtemplates", build_vignettes = TRUE)
+vignette("using_pdf_and_word_template")
 ```
 
 ## Requirements


### PR DESCRIPTION
the `build_vignettes` param now works