### PR TITLE
Setting biber as the bib engine

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -135,11 +135,12 @@ visc_pdf_document <- function(latex_engine = "pdflatex",
             to = "README.md",
             overwrite = FALSE)
 
-  rmarkdown::pdf_document(
+  bookdown::pdf_document2(
     template = template,
     keep_tex = keep_tex,
     fig_caption = TRUE,
     latex_engine = latex_engine,
+    bib_engine = 'biber',
     pandoc_args = c(
       "-V", paste0("logo_path_scharp=", logo_path_scharp),
       "-V", paste0("logo_path_fh=", logo_path_fh),

--- a/R/template.R
+++ b/R/template.R
@@ -106,7 +106,7 @@ use_bib <- function(study_name) {
 #'
 #' @param latex_engine latex engine to use
 #' @param keep_tex keep the .tex file
-#' @param ... other options to pass to \code{rmarkdown::pdf_document()}
+#' @param ... other options to pass to \code{bookdown::pdf_document2()}
 #'
 #' @details
 #'

--- a/man/visc_pdf_document.Rd
+++ b/man/visc_pdf_document.Rd
@@ -11,7 +11,7 @@ visc_pdf_document(latex_engine = "pdflatex", keep_tex = TRUE, ...)
 
 \item{keep_tex}{keep the .tex file}
 
-\item{...}{other options to pass to \code{rmarkdown::pdf_document()}}
+\item{...}{other options to pass to \code{bookdown::pdf_document2()}}
 }
 \description{
 Runs the VISC Report for PDF output based on the template.tex file.


### PR DESCRIPTION
This fixes the current warning when running a pdf report:
```
LaTeX Warning: There were undefined references.
Package biblatex Warning: Please (re)run Biber on the file:

```
Note to make this change needed to switch to `bookdown::pdf_document2`. Everything else seems to run the same as `rmarkdown::pdf_document`.