### PR TITLE
Fixed biber/bibtex issue with pdf output, updated news and version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: VISCtemplates
 Title: Tools for writing reproducible reports at VISC
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: 
     person(given = "Jimmy",
            family = "Fulp",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# VISCtemplates 0.3.1
+
+* Bug fix:
+    + Fixed biber/bibtex issue with pdf output.
+
 # VISCtemplates 0.3.0
 
 * New "empty" report template without the boilerplate PT report text.

--- a/R/template.R
+++ b/R/template.R
@@ -140,7 +140,6 @@ visc_pdf_document <- function(latex_engine = "pdflatex",
     keep_tex = keep_tex,
     fig_caption = TRUE,
     latex_engine = latex_engine,
-    bib_engine = 'biber',
     pandoc_args = c(
       "-V", paste0("logo_path_scharp=", logo_path_scharp),
       "-V", paste0("logo_path_fh=", logo_path_fh),

--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -6,7 +6,7 @@
 \usepackage{url}
 \usepackage[maxfloats=50]{morefloats}
 \usepackage{parskip}
-\usepackage[citestyle=authoryear-comp,natbib=true]{biblatex}
+%\usepackage[citestyle=authoryear-comp,natbib=true]{biblatex}
 \usepackage{pdflscape}
 \usepackage[absolute]{textpos}
 \usepackage{rotating} %for xtable sideways

--- a/man/set_pandoc_markup.Rd
+++ b/man/set_pandoc_markup.Rd
@@ -21,8 +21,8 @@ PDF (Latex) and Word document reports.
 
 pandoc_markup <- set_markup_warnings(output_type = get_output_type())
 
-my_results %>%
-  kable() %>%
+my_results \%>\%
+  kable() \%>\%
   cell_spec(pvalue, bold = ifelse(pandoc_markup, TRUE, FALSE))
 
 }


### PR DESCRIPTION
PT reports were compiling multiple time each knit, with the issue related to the bib file. After fixing I checked multiple recent PT reports and the tex file showed no change related to references, but the reports were running smoothly and only compiling once.