### PR TITLE
Hotfix/0.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: VISCtemplates
 Title: Tools for writing reproducible reports at VISC
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: 
     person(given = "Jimmy",
            family = "Fulp",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# VISCtemplates 0.3.3
+
+* Bug fix: updated `bibliography.bib` file to fix issue with Mac using bib files.
+
 # VISCtemplates 0.3.2
 
 * Bug fix: fixed pandoc error that complains about cslreferences.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # VISCtemplates 0.3.3
 
 * Bug fix: updated `bibliography.bib` file to fix issue with Mac using bib files.
+* Updated `visc_report/skeleton.Rmd` file in preparation of bug fix being addressed in VISCfunctions
 
 # VISCtemplates 0.3.2
 

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -273,7 +273,7 @@ ICS_adata %>%
 ```{r example-tab, results="asis", warning=kable_warnings}
 
 magnitude_tab <- magnitude_results %>% 
-  select(-Population, -PerfectSeperation) 
+  select(-Population, -contains('Perfect')) 
 
 magnitude_tab %>%
   kable(

--- a/inst/templates/bibliography.bib
+++ b/inst/templates/bibliography.bib
@@ -10,7 +10,7 @@
     year={PLoS Path, in press 2019}}
 
 @article{nolen2015,
-    title = {{Analysis of Repeated Low-Dose Challenge Studies}},
+    title = {Analysis of Repeated Low-Dose Challenge Studies},
     volume = {34},
     issn = {1097-0258},
     doi = {10.1002/sim.6462},
@@ -37,7 +37,7 @@
 
 @article{ritz2015,
     title={Dose-Response Analysis Using R},
-    author={Ritz C, Baty F, Streibig JC, Gerhard D },
+    author={Ritz C, Baty F, Streibig JC, Gerhard D},
     journal={PLoS ONE},
     volume={10},
     number={12},
@@ -86,7 +86,7 @@
 
 @article{Bomsel:2011aa,
    Author="Bomsel, M.  and Tudor, D.  and Drillet, A. S.  and Alfsen, A.  and Ganor, Y.  and Roger, M. G.  and Mouz, N.  and Amacker, M.  and Chalifour, A.  and Diomede, L.  and Devillier, G.  and Cong, Z.  and Wei, Q.  and Gao, H.  and Qin, C.  and Yang, G. B.  and Zurbriggen, R.  and Lopalco, L.  and Fleury, S. ",
-   Title="{{I}mmunization with {H}{I}{V}-1 gp41 subunit virosomes induces mucosal antibodies protecting nonhuman primates against vaginal {S}{H}{I}{V} challenges}",
+   Title={{I}mmunization with {H}{I}{V}-1 gp41 subunit virosomes induces mucosal antibodies protecting nonhuman primates against vaginal {S}{H}{I}{V} challenges},
    Journal="Immunity",
    Year="2011",
    Volume="34",
@@ -96,8 +96,8 @@
 }
 
 @article{AgCo1998,
-  author = {{Agresti, A. and Coull, B.}},
-  title = {{Approximate Is Better than "Exact" for Interval Estimation of Binomial Proportions}},
+  author = {Agresti, A. and Coull, B.},
+  title = {Approximate Is Better than "Exact" for Interval Estimation of Binomial Proportions},
   journal = {The American Statistician},
   year = {1998},
   volume = {52},
@@ -106,7 +106,7 @@
 
 @article{Huang:2013fl,
   author = {Huang, Yunda and Gottardo, Rapha{\"e}l},
-  title = {{Comparability and reproducibility of biomedical data.}},
+  title = {Comparability and reproducibility of biomedical data.},
   journal = {Briefings in bioinformatics},
   year = {2013},
   volume = {14},
@@ -176,7 +176,7 @@
 }
 
 @article{yates2014,
-	title = {Vaccine-{Induced} {Env} {V}1-{V}2 {IgG}3 {Correlates} with {Lower} {HIV}-1 {Infection} {Risk} and {Declines} {Soon} {After} {Vaccination}},
+	title = {Vaccine-Induced Env V1-V2 IgG3 Correlates with Lower HIV-1 Infection Risk and Declines Soon After Vaccination},
 	volume = {6},
 	issn = {1946-6234, 1946-6242},
 	url = {http://stm.sciencemag.org/content/6/228/228ra39},
@@ -186,14 +186,14 @@
 	urldate = {2015-06-04},
 	journal = {Science Translational Medicine},
 	author = {Yates, Nicole L. and Liao, Hua-Xin and Fong, Youyi and deCamp, Allan and Vandergrift, Nathan A. and Williams, William T. and Alam, S. Munir and Ferrari, Guido and Yang, Zhi-yong and Seaton, Kelly E. and Berman, Phillip W. and Alpert, Michael D. and Evans, David T. and O’Connell, Robert J. and Francis, Donald and Sinangil, Faruk and Lee, Carter and Nitayaphan, Sorachai and Rerks-Ngarm, Supachai and Kaewkungwal, Jaranit and Pitisuttithum, Punnee and Tartaglia, James and Pinter, Abraham and Zolla-Pazner, Susan and Gilbert, Peter B. and Nabel, Gary J. and Michael, Nelson L. and Kim, Jerome H. and Montefiori, David C. and Haynes, Barton F. and Tomaras, Georgia D.},
-	month = mar,
+	month = {mar},
 	year = {2014},
 	pmid = {24648342},
 	pages = {228ra39--228ra39}
 }
 
 @article{hudgens_assessing_2009,
-	title = {Assessing {Vaccine} {Effects} in {Repeated} {Low}-{Dose} {Challenge} {Experiments}},
+	title = {Assessing Vaccine Effects in Repeated Low-Dose Challenge Experiments},
 	volume = {65},
 	copyright = {© 2009, The International Biometric Society},
 	issn = {1541-0420},
@@ -205,7 +205,7 @@
 	urldate = {2016-05-12},
 	journal = {Biometrics},
 	author = {Hudgens, Michael G. and Gilbert, Peter B.},
-	month = dec,
+	month = {dec},
 	year = {2009},
 	keywords = {Causal inference, Correlates of protection, HIV, Potential outcomes, Surrogate marker, Vaccine trial},
 	pages = {1223--1232}
@@ -213,7 +213,7 @@
 
 @article{Benjamini:95,
   author = {Benjamini, Yoav and Hochberg, Yosef},
-  title = {{Controlling the false discovery rate: a practical and powerful approach to multiple testing.}},
+  title = {Controlling the false discovery rate: a practical and powerful approach to multiple testing.},
   journal = {Journal of the Royal Statistical Society, Series B},
   year = {1995},
   volume = {57},
@@ -239,10 +239,9 @@
 	publisher = "John Wiley & Sons"
 }
 
-
 @Article{haynes2012,
    Author="Haynes, B. F.  and Gilbert, P. B.  and McElrath, M. J.  and Zolla-Pazner, S.  and Tomaras, G. D.  and Alam, S. M.  and Evans, D. T.  and Montefiori, D. C.  and Karnasuta, C.  and Sutthent, R.  and Liao, H. X.  and DeVico, A. L.  and Lewis, G. K.  and Williams, C.  and Pinter, A.  and Fong, Y.  and Janes, H.  and DeCamp, A.  and Huang, Y.  and Rao, M.  and Billings, E.  and Karasavvas, N.  and Robb, M. L.  and Ngauy, V.  and de Souza, M. S.  and Paris, R.  and Ferrari, G.  and Bailer, R. T.  and Soderberg, K. A.  and Andrews, C.  and Berman, P. W.  and Frahm, N.  and De Rosa, S. C.  and Alpert, M. D.  and Yates, N. L.  and Shen, X.  and Koup, R. A.  and Pitisuttithum, P.  and Kaewkungwal, J.  and Nitayaphan, S.  and Rerks-Ngarm, S.  and Michael, N. L.  and Kim, J. H. ",
-   Title="{{I}mmune-correlates analysis of an {H}{I}{V}-1 vaccine efficacy trial}",
+   Title={{I}mmune-correlates analysis of an {H}{I}{V}-1 vaccine efficacy trial},
    Journal="N. Engl. J. Med.",
    Year="2012",
    Volume="366",
@@ -274,7 +273,7 @@
 
 @article{Montefiori2005,
   author = {Montefiori, D.C.},
-  title = {{Evaluating neutralizing antibodies against HIV, SIV, and SHIV in luciferase gene reporter gene assays.}},
+  title = {Evaluating neutralizing antibodies against HIV, SIV, and SHIV in luciferase gene reporter gene assays.},
   journal = {Curr. Protoc. Immunol.},
   year = {2005},
   volume = {Chapter 12},
@@ -282,8 +281,8 @@
 }
 
 @article{Seaman2010,
-  author = {{Seaman, M.S. et al.}},
-  title = {{Tiered categorization of a diverse panel of HIV-1 Env pseudoviruses for assessments of neutralizing antibodies.}},
+  author = {Seaman, M.S. et al.},
+  title = {Tiered categorization of a diverse panel of HIV-1 Env pseudoviruses for assessments of neutralizing antibodies.},
   journal = {Journal of Virology},
   year = {2010},
   volume = {84},
@@ -291,8 +290,8 @@
 }
 
 @article{LiGao2005,
-  author = {{Li, M., Gao, F. et al.}},
-  title = {{Human immunodeficiency virus type 1 env clones from acute and early subtype B infections for standardized assessments of vaccine-elicited neutralizing antibodies.}},
+  author = {Li, M., Gao, F. et al.},
+  title = {Human immunodeficiency virus type 1 env clones from acute and early subtype B infections for standardized assessments of vaccine-elicited neutralizing antibodies.},
   journal = {Journal of Virology},
   year = {2005},
   volume = {79},
@@ -300,8 +299,8 @@
 }
 
 @article{LiSalazar2006,
-  author = {{Li, M., Salazar-Gonzalez, J.F. et al.}},
-  title = {{Genetic and neutralization properties of subtype C human immunodeficiency virus type 1 molecular env clones from acute and early heterosexually acquired infections in southern Africa.}},
+  author = {Li, M., Salazar-Gonzalez, J.F. et al.},
+  title = {Genetic and neutralization properties of subtype C human immunodeficiency virus type 1 molecular env clones from acute and early heterosexually acquired infections in southern Africa.},
   journal = {Journal of Virology},
   year = {2006},
   volume = {80},
@@ -310,7 +309,7 @@
 
 @article{Montefiori2009,
    Author="Montefiori, D. C. ",
-   Title="{{Measuring HIV neutralization in a luciferase reporter gene assay}}",
+   Title={Measuring HIV neutralization in a luciferase reporter gene assay},
    Journal="Methods Mol. Biol.",
    Year="2009",
    Volume="485",
@@ -319,7 +318,7 @@
 
 @article{Sarzotti-Kelsoe2014,
    Author="Sarzotti-Kelsoe, M.  and Bailer, R. T.  and Turk, E.  and Lin, C. L.  and Bilska, M.  and Greene, K. M.  and Gao, H.  and Todd, C. A.  and Ozaki, D. A.  and Seaman, M. S.  and Mascola, J. R.  and Montefiori, D. C. ",
-   Title="{{Optimization and validation of the TZM-bl assay for standardized assessments of neutralizing antibodies against HIV-1}}",
+   Title={Optimization and validation of the TZM-bl assay for standardized assessments of neutralizing antibodies against HIV-1},
    Journal="J. Immunol. Methods",
    Year="2014",
    Volume="409",
@@ -329,7 +328,7 @@
 
 @article{deCamp2014,
    Author="deCamp, A.  and Hraber, P.  and Bailer, R. T.  and Seaman, M. S.  and Ochsenbauer, C.  and Kappes, J.  and Gottardo, R.  and Edlefsen, P.  and Self, S.  and Tang, H.  and Greene, K.  and Gao, H.  and Daniell, X.  and Sarzotti-Kelsoe, M.  and Gorny, M. K.  and Zolla-Pazner, S.  and LaBranche, C. C.  and Mascola, J. R.  and Korber, B. T.  and Montefiori, D. C. ",
-   Title="{{Global panel of HIV-1 Env reference strains for standardized assessments of vaccine-elicited neutralizing antibodies}}",
+   Title={Global panel of HIV-1 Env reference strains for standardized assessments of vaccine-elicited neutralizing antibodies},
    Journal="J. Virol.",
    Year="2014",
    Volume="88",
@@ -340,7 +339,7 @@
 
 @article{MIMOSA2014,
    Author="Finak, G.  and McDavid, A.  and Chattopadhyay, P.  and Dominguez, M.  and De Rosa, S.  and Roederer, M.  and Gottardo, R. ",
-   Title="{{M}ixture models for single-cell assays with applications to vaccine studies}",
+   Title={{M}ixture models for single-cell assays with applications to vaccine studies},
    Journal="Biostatistics",
    Year="2014",
    Volume="15",
@@ -351,7 +350,7 @@
 
 @article{COMPASS2014,
    Author="Lin, L.  and Finak, G.  and Ushey, K.  and Seshadri, C.  and Hawn, T. R.  and Frahm, N.  and Scriba, T. J.  and Mahomed, H.  and Hanekom, W.  and Bart, P. A.  and Pantaleo, G.  and Tomaras, G. D.  and Rerks-Ngarm, S.  and Kaewkungwal, J.  and Nitayaphan, S.  and Pitisuttithum, P.  and Michael, N. L.  and Kim, J. H.  and Robb, M. L.  and O'Connell, R. J.  and Karasavvas, N.  and Gilbert, P.  and C De Rosa, S.  and McElrath, M. J.  and Gottardo, R. ",
-   Title="{{C}{O}{M}{P}{A}{S}{S} identifies {T}-cell subsets correlated with clinical outcomes}",
+   Title={{C}{O}{M}{P}{A}{S}{S} identifies {T}-cell subsets correlated with clinical outcomes},
    Journal="Nat. Biotechnol.",
    Year="2015",
    Volume="33",
@@ -362,7 +361,7 @@
 
 @article{Newton2004,
    Author="Newton, M. A.  and Noueiry, A.  and Sarkar, D.  and Ahlquist, P. ",
-   Title="{{D}etecting differential gene expression with a semiparametric hierarchical mixture method}",
+   Title={{D}etecting differential gene expression with a semiparametric hierarchical mixture method},
    Journal="Biostatistics",
    Year="2004",
    Volume="5",
@@ -372,8 +371,8 @@
 }
 
 @article{Pollara2014,
-  author = {{Pollara, J., Bonsignori, M. et al.}},
-  title = {{HIV-1 vaccine-induced C1 and V2 Env-specific antibodies synergize for increased antiviral activities.}},
+  author = {Pollara, J., Bonsignori, M. et al.},
+  title = {HIV-1 vaccine-induced C1 and V2 Env-specific antibodies synergize for increased antiviral activities.},
   journal = {J Virol.},
   year = {2014},
   volume = {88(14)},
@@ -381,8 +380,8 @@
 }
 
 @article{Sambor2014,
-  author = {{Sambor, A. et al.}},
-  title = {{Establishment and maintenance of a PBMC repository for functional cellular studies in support of clinical vaccine trials.}},
+  author = {Sambor, A. et al.},
+  title = {Establishment and maintenance of a PBMC repository for functional cellular studies in support of clinical vaccine trials.},
   journal = {J Immunol Methods.},
   year = {2014},
   volume = {409},
@@ -390,8 +389,8 @@
 }
 
 @article{Pollara2011,
-  author = {{Pollara, J., Hart, L. et al.}},
-  title = {{High-throughput quantitative analysis of HIV-1 and SIV-specific ADCC-mediating antibody responses.}},
+  author = {Pollara, J., Hart, L. et al.},
+  title = {High-throughput quantitative analysis of HIV-1 and SIV-specific ADCC-mediating antibody responses.},
   journal = {Cytometry A.},
   year = {2011},
   volume = {79(8)},
@@ -399,7 +398,7 @@
 }
 
 @article{tomaras_polyclonal_2011,
-	title = {Polyclonal {B} cell responses to conserved neutralization epitopes in a subset of {HIV}-1-infected individuals},
+	title = {Polyclonal B cell responses to conserved neutralization epitopes in a subset of HIV-1-infected individuals},
 	volume = {85},
 	issn = {1098-5514},
 	doi = {10.1128/JVI.05363-11},
@@ -413,48 +412,4 @@
 	pmcid = {PMC3194956},
 	keywords = {Antibodies, Neutralizing, B-Lymphocytes, Epitopes, B-Lymphocyte, HIV-1, HIV Antibodies, HIV Envelope Protein gp41, HIV Envelope Protein gp120, HIV Infections, Humans},
 	pages = {11502--11519}
-}
-
-@software{mlxr,
-  title={mlxR: simulation of longitudinal data},
-  author={Lavielle, M and Ilinca, E and Kuate, R},
-  year={2020},
-  version={4.1.2},
-  url={http://simulx.webpopix.org/}
-}
-
-@software{monolix,
-  author = {{Lixoft}},
-  title = {Monolix},
-  url = {http://lixoft.com/products/monolix/},
-  version = {2019R1},
-  date = {2019}
-}
-
-@software{pkanalix,
-  author = {{Lixoft}},
-  title = {PKanalix},
-  url = {http://lixoft.com/products/PKanalix/},
-  version = {2019R1},
-  year = {2019}
-}
-
-@Article{tidyverse,
-  title = {Welcome to the {tidyverse}},
-  author = {Hadley Wickham and Mara Averick and Jennifer Bryan and Winston Chang and Lucy D'Agostino McGowan and Romain François and Garrett Grolemund and Alex Hayes and Lionel Henry and Jim Hester and Max Kuhn and Thomas Lin Pedersen and Evan Miller and Stephan Milton Bache and Kirill Müller and Jeroen Ooms and David Robinson and Dana Paige Seidel and Vitalie Spinu and Kohske Takahashi and Davis Vaughan and Claus Wilke and Kara Woo and Hiroaki Yutani},
-  year = {2019},
-  journal = {Journal of Open Source Software},
-  volume = {4},
-  number = {43},
-  pages = {1686},
-  doi = {10.21105/joss.01686}
-}
-
-@Manual{rlang,
-  title = {R: A Language and Environment for Statistical Computing},
-  author = {{R Core Team}},
-  organization = {R Foundation for Statistical Computing},
-  address = {Vienna, Austria},
-  year = {2019},
-  url = {https://www.R-project.org/}
 }

--- a/inst/templates/bibliography.bib
+++ b/inst/templates/bibliography.bib
@@ -413,3 +413,47 @@
 	keywords = {Antibodies, Neutralizing, B-Lymphocytes, Epitopes, B-Lymphocyte, HIV-1, HIV Antibodies, HIV Envelope Protein gp41, HIV Envelope Protein gp120, HIV Infections, Humans},
 	pages = {11502--11519}
 }
+
+@software{mlxr,
+  title={mlxR: simulation of longitudinal data},
+  author={Lavielle, M and Ilinca, E and Kuate, R},
+  year={2020},
+  version={4.1.2},
+  url={http://simulx.webpopix.org/}
+}
+
+@software{monolix,
+  author = {Lixoft},
+  title = {Monolix},
+  url = {http://lixoft.com/products/monolix/},
+  version = {2019R1},
+  year = {2019}
+}
+
+@software{pkanalix,
+  author = {Lixoft},
+  title = {PKanalix},
+  url = {http://lixoft.com/products/PKanalix/},
+  version = {2019R1},
+  year = {2019}
+}
+
+@Article{tidyverse,
+  title = {Welcome to the tidyverse},
+  author = {Hadley Wickham and Mara Averick and Jennifer Bryan and Winston Chang and Lucy D'Agostino McGowan and Romain François and Garrett Grolemund and Alex Hayes and Lionel Henry and Jim Hester and Max Kuhn and Thomas Lin Pedersen and Evan Miller and Stephan Milton Bache and Kirill Müller and Jeroen Ooms and David Robinson and Dana Paige Seidel and Vitalie Spinu and Kohske Takahashi and Davis Vaughan and Claus Wilke and Kara Woo and Hiroaki Yutani},
+  year = {2019},
+  journal = {Journal of Open Source Software},
+  volume = {4},
+  number = {43},
+  pages = {1686},
+  doi = {10.21105/joss.01686}
+}
+
+@Manual{rlang,
+  title = {R: A Language and Environment for Statistical Computing},
+  author = {R Core Team},
+  organization = {R Foundation for Statistical Computing},
+  address = {Vienna, Austria},
+  year = {2019},
+  url = {https://www.R-project.org/}
+}


### PR DESCRIPTION
* Bug fix: updated `bibliography.bib` file to fix issue with Mac using bib files.
* Updated `visc_report/skeleton.Rmd` file in preparation of bug fix being addressed in VISCfunctions (Fixing misspelled `PerfectSeperation` var name
