### PR TITLE
Update rlang citation

### DIFF
--- a/inst/templates/bibliography.bib
+++ b/inst/templates/bibliography.bib
@@ -451,7 +451,7 @@
 
 @Manual{rlang,
   title = {R: A Language and Environment for Statistical Computing},
-  author = {R Core Team},
+  author = {{R Core Team}},
   organization = {R Foundation for Statistical Computing},
   address = {Vienna, Austria},
   year = {2019},


### PR DESCRIPTION
Adding another set of curly brackets. Otherwise it gets cited as "Team, R Core".