### PR TITLE
Add `\sloppy` so that text does not spill into margin. Addresses #71.

### DIFF
--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -197,6 +197,7 @@ $endif$
 \setlength{\parindent}{0pt}
 %\makeglossaries
 \begin{document}
+\sloppy
 
 %get current date into insertdate
 \makeatletter


### PR DESCRIPTION
Hi Jimmy, I did some initial testing and adding `\sloppy` to the .tex file works for me. Could you do more testing? I'm not sure what you were thinking of in terms of unintended consequences. Or let me know if you want me to assign someone else to review. 