### PR TITLE
Add new checks for project name and existence of directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Description: The goal of VISCtemplates is to automate project setup provide a co
 License: GPL-3 + file LICENSE
 Depends: R (>= 3.0)
 Imports:
+    fs,
     bookdown,
     here,
     rmarkdown,

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -10,6 +10,7 @@ create_visc_project <- function(path){
 
   # top level folder should follow VDCNNNAnalysis format
   repo_name <- basename(path)
+  challenge_visc_name(repo_name)
 
   # get "VDCNNN" if it exists
   # this is a variable that is inserted into templates
@@ -72,6 +73,19 @@ challenge_directory <- function(path) {
   }
 }
 
+
+challenge_visc_name <- function(repo_name) {
+
+  continue <- usethis::ui_yeah("
+    Creating a new VISC project called {repo_name}.
+    At VISC, we use a naming convention for analysis projects, VDCnnnAnalysis,
+    where 'VDC' is the CAVD PI name, and 'nnn' is the CAVD project number.
+    Would you like to continue?")
+
+  if (!continue) {
+    usethis::ui_stop("Stopping `create_visc_project()`")
+    }
+}
 
 # Set up project with RStudio GUI ----------------------------------------------
 

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -6,6 +6,8 @@
 #' @export
 create_visc_project <- function(path){
 
+  challenge_directory(path)
+
   # top level folder should follow VDCNNNAnalysis format
   repo_name <- basename(path)
 
@@ -20,7 +22,7 @@ create_visc_project <- function(path){
   # create package
   usethis::create_package(
     path = path
-  ) # add check for existing package
+  )
 
   # must set active project otherwise it is <no active project>
   usethis::proj_set(path = path)
@@ -47,6 +49,28 @@ create_visc_project <- function(path){
 
 }
 
+
+challenge_directory <- function(path) {
+
+  path <- fs::path_expand(path)
+
+  dir_exists <- dir.exists(path)
+
+  if (dir_exists) {
+
+    continue <- usethis::ui_yeah("
+      The directory {path} already exists.
+      Would you like to continue?")
+
+    if (!continue) {
+      usethis::ui_stop("Stopping `create_visc_project()`")
+    } else if (continue) {
+      usethis::ui_warn("
+        Creating new VISC project in {path}, which already exists.
+        Be sure to check the directory for unexpected files.")
+    }
+  }
+}
 
 
 # Set up project with RStudio GUI ----------------------------------------------


### PR DESCRIPTION
`VISCtemplates::create_visc_project()` already checks for existence of .Rproj file and DESCRIPTION file in the path for the new project because it is built on `usethis::create_package()`. 

This PR adds two additional steps:

1) reminds the user of VISC analysis project naming conventions and asks if they would like to continue (#5 )
2) checks if directory exists, and if it exists, asks the user if they would like to continue (#13 )