### PR TITLE
Turn study-schema.R into an actual function

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -84,7 +84,7 @@ use_group_colors <- function(study_name) {
 use_study_schema <- function(study_name) {
   usethis::use_template(
     template = "study-schema.R",
-    save_as = "docs/study-schema.R",
+    save_as = "R/study-schema.R",
     data = list(study_name = study_name),
     package = "VISCtemplates"
   )

--- a/inst/templates/study-schema.R
+++ b/inst/templates/study-schema.R
@@ -1,12 +1,28 @@
-## Study Schema for {{ study_name }}
+#' Study Schema for {{ study_name }}
+#'
+#' To source the study schema in a chunk in your Rmarkdown report:
+#' source("R/study-schema.R")
+#'
+#' @return a kable table with the study schema
+#' @export
+#'
+#' @examples
+study_schema <- function() {
 
-# Edit the code below to set up a shared study schema across PT reports.
+  caption <- "{{ study_name }} study schema."
 
-study_schema <- tibble::tribble(
-  ~Group, ~`Sample Size`, ~`Week 10`, ~`Week 20`,
-  "Group A", 10, "Dose A", "Dose A",
-  "Group B", 10, "Dose B", "Dose B"
-)
+  schema_table <- tibble::tribble(
+    ~Group, ~`Sample Size`, ~`Week 10`, ~`Week 20`,
+    "Group A", 10, "Dose A", "Dose A",
+    "Group B", 10, "Dose B", "Dose B"
+    )
 
-# To source the study schema in a chunk in your Rmarkdown report:
-#  knitr::read_chunk("protocol/study-schema.R")
+  schema_table %>%
+    knitr::kable(
+      format = output_type,
+      caption = caption,
+      booktabs = TRUE,
+      linesep = ""
+    ) %>%
+    kableExtra::kable_styling(latex_options = c("hold_position"))
+  }

--- a/inst/templates/study_schema.R
+++ b/inst/templates/study_schema.R
@@ -3,13 +3,13 @@
 #' To source the study schema in a chunk in your Rmarkdown report:
 #' source("R/study_schema.R")
 #'
+#' @param caption caption for the study schema table
+#'
 #' @return a kable table with the study schema
 #' @export
 #'
 #' @examples
-study_schema <- function() {
-
-  caption <- "{{ study_name }} study schema."
+study_schema <- function(caption = "{{ study_name }} study schema.") {
 
   schema_table <- tibble::tribble(
     ~Group, ~`Sample Size`, ~`Week 10`, ~`Week 20`,
@@ -19,7 +19,7 @@ study_schema <- function() {
 
   schema_table %>%
     knitr::kable(
-      format = output_type,
+      format = VISCtemplates::get_output_type(),
       caption = caption,
       booktabs = TRUE,
       linesep = ""

--- a/inst/templates/study_schema.R
+++ b/inst/templates/study_schema.R
@@ -1,7 +1,7 @@
 #' Study Schema for {{ study_name }}
 #'
 #' To source the study schema in a chunk in your Rmarkdown report:
-#' source("R/study-schema.R")
+#' source("R/study_schema.R")
 #'
 #' @return a kable table with the study schema
 #' @export


### PR DESCRIPTION
This PR turns the code to create a study schema into a function, creates a template for documenting the function, and moves the template code to the R/ folder. Closes #79 