### PR TITLE
NAb template draft

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -113,9 +113,9 @@ use_bib <- function(study_name) {
 #' }
 use_visc_report <- function(report_name = "PT-Report",
                             path = ".",
-                            report_type = c("empty", "generic", "bama")) {
+                            report_type = c("empty", "generic", "bama", "nab")) {
 
-  stopifnot(report_type %in% c("empty", "generic", "bama"))
+  stopifnot(report_type %in% c("empty", "generic", "bama", "nab"))
 
   if (report_type == "empty") {
     rmarkdown::draft(

--- a/inst/templates/methods-nab/nab-biological-endpoints.Rmd
+++ b/inst/templates/methods-nab/nab-biological-endpoints.Rmd
@@ -1,0 +1,16 @@
+---
+title: "{{ study_name}} Biological Endpoints"
+output: github_document
+---
+
+<!-- This file was adapted from VISCtemplates {{pkg_ver}}. -->
+
+<!--- Note ID80 is also often included, along with ID50. Check lab study plan. --->
+
+Neutralization ID~50~ <!--- and/or ID80 ---> titers were measured by a HIV 
+neutralizing antibody (NAb) assay from specimens obtained at weeks 
+<!--- list weeks ---> 
+corresponding to <!--- specify the timing in relationship to vaccinations e.g., 
+corresponding to 2 weeks after the 1st vaccination and 2 weeks after the 2nd 
+vaccination --->. 
+

--- a/inst/templates/methods-nab/nab-lab-methods.Rmd
+++ b/inst/templates/methods-nab/nab-lab-methods.Rmd
@@ -5,8 +5,11 @@ output: github_document
 
 <!-- This file was adapted from VISCtemplates {{pkg_ver}}. -->
 
-<!--- Refer to the protocol-specific lab study plan for the specific tiers, 
-cell types, and pseudoviruses. --->
+<!-- Refer to the protocol-specific lab study plan for the specific tiers, 
+cell types, and pseudoviruses. 
+CATNAP may be a helpful resource:
+https://www.hiv.lanl.gov/components/sequence/HIV/neutralization/
+-->
 
 Neutralizing antibodies against HIV-1 pseudoviruses were measured as a function 
 of reduction in Tat-regulated luciferase (Luc) reporter gene expression in 

--- a/inst/templates/methods-nab/nab-lab-methods.Rmd
+++ b/inst/templates/methods-nab/nab-lab-methods.Rmd
@@ -1,0 +1,26 @@
+---
+title: "{{ study_name}} Lab Methods"
+output: github_document
+---
+
+<!-- This file was adapted from VISCtemplates {{pkg_ver}}. -->
+
+<!--- Refer to the protocol-specific lab study plan for the specific tiers, 
+cell types, and pseudoviruses. --->
+
+Neutralizing antibodies against HIV-1 pseudoviruses were measured as a function 
+of reduction in Tat-regulated luciferase (Luc) reporter gene expression in 
+TZM-bl cells [@Montefiori2009], [@Sarzotti-Kelsoe2014]. 
+Neutralization titer was defined as the serum dilution at which relative 
+luminescence units (RLUs) were reduced by 50% (ID~50~) relative to the RLUs in 
+virus control wells (cell + virus only) after subtraction of background RLUs 
+(wells with cells only). 
+The assay performed in TZM-bl cells measured neutralization titers against a 
+panel of <!--- autologous and ---> heterologous Env-pseudotyped viruses.
+[x] pseudoviruses were tested, consisting of [fill in virus, clade, tier], 
+<!-- Check protocol and lab study plan for panel and negative control info. -->
+as well as the global pseudovirus panel and a negative control (SVA-MLV)
+[@deCamp2014]. 
+
+<!-- Consider adding a table to list pseudovirus tier, subtype, 
+vaccine strain (yes/no), and isolate name (e.g., MW965.26) -->

--- a/inst/templates/methods-nab/nab-statistical-methods.Rmd
+++ b/inst/templates/methods-nab/nab-statistical-methods.Rmd
@@ -1,0 +1,121 @@
+---
+title: "Statistical Methods"
+output: github_document
+---
+
+<!-- This file was adapted from VISCtemplates {{pkg_ver}}. -->
+
+## Statistical Endpoints
+
+<!-- Animal studies usually use SLA-MLV-subtracted values. Check the lab study plan
+for more info. -->
+
+Response to a pseudovirus was considered to be positive if the net ID~50~ titer 
+was greater than or equal to 20.
+The net ID~50~ titer (the SLA-MLV-subtracted neutralization titer) is the 
+pseudovirus ID~50~ titer value minus the SLA-MLV ID~50~ titer value, calculated 
+for each animal and timepoint.
+SLA-MLV ID~50~ titer values less than 20 were truncated at 10 before subtraction.  
+Response rates were calculated for each group and time point with corresponding 
+95% two-sided Wilson score confidence intervals.
+
+The response magnitude was defined as the log~10~ net ID~50~ titer.
+
+To measure durability, the fold-change in response magnitude (log~10~ net ID~50~ 
+titer) between week [peak] (peak time point) and week [post-peak] was calculated. 
+The fold-change was only calculated for pseudoviruses with samples at both time 
+points and for animals with positive responses at 
+week [peak], <!--usually first sample taken after last vaccination --> 
+defined as:
+
+$$\mathrm{Fold\mbox{-}change} = \frac{X_{\text{week [peak]}}}{X_{\text{week [post-peak]}}}$$
+
+where X represents the response magnitude.
+
+## Graphical Analysis
+
+Response rates were plotted, with accompanying Wilson score confidence 
+intervals, for each experimental group and pseudovirus at each time point.
+
+Distributions of net ID~50~ titers on log~10~ scale and durability (fold-change 
+in response magnitude from peak to each durability time point) were plotted by 
+experimental group and pseudovirus with superimposed box plots. 
+In plots of net ID~50~ titers, box plots were superimposed on the distribution 
+of responders. 
+The mid-line of the box denotes the median and the ends of the box denote the 
+25^th^ and 75^th^ percentiles. 
+The whiskers denote the most extreme data points that were no more than 1.5 
+times the interquartile range (i.e., height of the box). 
+Response proportions at week [peak] <!-- peak time point --> are displayed above
+durability box plots for each experimental group and pseudovirus with 
+responers at week [peak] <!-- peak time point -->.
+
+<!--- If MB curves plotted, include the following. ---> 
+Magnitude-breadth (MB) curves characterize the magnitude (net ID~50~ titer) and 
+breadth (number of isolates neutralized at a given titer) of each individual 
+plasma sample assayed against a panel of isolates [@Huang2009].  
+The x-axis represents the neutralization titer (t) and the y-axis represents 
+the fraction of isolates with neutralization titers greater than t.  
+In addition to the individual sample-specific curves, the group-specific curve 
+displays the average MB across all subjects in that group. 
+<!--- If AUC-MB calculated, include the following. ---> 
+The AUC-MB was calculated as the average of the log~10~ net ID~50~ titers over 
+the panel of isolates, where titers that were below the limit-of-detection were 
+set to 10. AUC-MB values calculated from the MB curves were displayed as box 
+plots for each experimental group.
+
+To show response trends over time, line plots of log~10~ net ID~50~ titer 
+by pseudovirus and experimental group were plotted for each pseudovirus with
+samples at multiple time points.
+
+## Statistical Tests
+
+<!-- The following is only a guide. Please refer to the SAP for specific 
+information on statistical tests. --> 
+
+Statistical tests were performed as pairwise tests between the experimental 
+groups at weeks <!-- Refer to the SAP for timepoints tested -->. 
+
+Pairwise comparisons of response rates between experimental groups for each 
+pseudovirus were conducted using Barnard's exact test (two-sided, alpha = 0.05) 
+[@Lyderson2009], [@Suissa1985]. 
+
+Pairwise comparisons of response magnitudes (log~10~ net ID~50~ titers) were 
+made between experimental groups for each pseudovirus using the Wilcoxon 
+rank-sum test (two-sided, alpha = 0.05).
+<!-- Check the SAP for details on inclusion criteria. -->
+Response magnitude tests included responders and non-responders (with truncated 
+net ID~50~ titer measurements). 
+All magnitude tests required at least 3 responders in at least one of the groups 
+being compared.
+
+Pairwise comparisons of AUC-MB were made between experimental groups for the 
+global pseudovirus panel at week <!-- Add time point. --> using the Wilcoxon 
+rank-sum test (two-sided, alpha = 0.05). 
+AUC-MB tests included responders and non-responders (with truncated net ID~50~ 
+titer measurements). 
+
+Pairwise comparisons of the durability (fold-change) between 
+week <!-- peak time point --> and week <!-- durability time point -->
+were performed between experimental groups using the log-rank test 
+(two-sided, alpha = 0.05) with Wilcoxon-Mann-Whitney scores and interval 
+censoring for each pseudovirus (@Fay). 
+The method outlined by @Fay2012 maintains the type I error rate under 
+assessment-treatment dependence. 
+A fold-change was considered censored when the net ID~50~ titer value at the 
+durability time point was below the limit of detection. 
+The lower bound of the interval was set to 
+$\mathrm{log_{10}}$$\mathrm{(1/X_{\text{week [peak]}})}$ 
+and the upper bound of the interval was set to 
+$\mathrm{log_{10}}$$\mathrm{(20/X_{\text{week [peak]}})}$ 
+for censored values, where X represents net ID~50~ titer and 20 is the limit
+of detection for the NAb assay.
+Tests were only performed for pairs of groups where both groups had at least 3 
+positive responders at week <!-- peak time point -->, and the median fold-change 
+for at least one group was observed (i.e., there were at least as many 
+uncensored values as censored values for at least one group).
+
+Corrections for multiple testing were not done for this analysis. 
+<!-- If there were p-value adjustments, specify the method (i.e. FDR) and what 
+grouping variables the adjustment will be made over (i.e. adjusting over 
+isolates). -->

--- a/inst/templates/methods-nab/nab-statistical-methods.Rmd
+++ b/inst/templates/methods-nab/nab-statistical-methods.Rmd
@@ -7,19 +7,25 @@ output: github_document
 
 ## Statistical Endpoints
 
-<!-- Animal studies usually use SLA-MLV-subtracted values. Check the lab study plan
-for more info. -->
+<!-- 
+Animal studies usually use SLA-MLV-subtracted values. 
+Check with the lab and lead statistician. 
+If using SLA-MLV-subtracted values, replace "ID~50~ titer" with 
+"net ID~50~ titer" or "MLV-subtracted titer" (use one, be consistent).
+-->
 
-Response to a pseudovirus was considered to be positive if the net ID~50~ titer 
+Response to a pseudovirus was considered to be positive if the [net] ID~50~ titer 
 was greater than or equal to 20.
+<!-- if using SLA-MLV-subtracted values: 
 The net ID~50~ titer (the SLA-MLV-subtracted neutralization titer) is the 
 pseudovirus ID~50~ titer value minus the SLA-MLV ID~50~ titer value, calculated 
 for each animal and timepoint.
 SLA-MLV ID~50~ titer values less than 20 were truncated at 10 before subtraction.  
+-->
 Response rates were calculated for each group and time point with corresponding 
 95% two-sided Wilson score confidence intervals.
 
-The response magnitude was defined as the log~10~ net ID~50~ titer.
+The response magnitude was defined as the log~10~ ID~50~ titer.
 
 To measure durability, the fold-change in response magnitude (log~10~ net ID~50~ 
 titer) between week [peak] (peak time point) and week [post-peak] was calculated. 
@@ -35,23 +41,23 @@ where X represents the response magnitude.
 ## Graphical Analysis
 
 Response rates were plotted, with accompanying Wilson score confidence 
-intervals, for each experimental group and pseudovirus at each time point.
+intervals, for each group and pseudovirus at each time point.
 
-Distributions of net ID~50~ titers on log~10~ scale and durability (fold-change 
+Distributions of ID~50~ titers on log~10~ scale and durability (fold-change 
 in response magnitude from peak to each durability time point) were plotted by 
-experimental group and pseudovirus with superimposed box plots. 
-In plots of net ID~50~ titers, box plots were superimposed on the distribution 
+group and pseudovirus with superimposed box plots. 
+In plots of ID~50~ titers, box plots were superimposed on the distribution 
 of responders. 
 The mid-line of the box denotes the median and the ends of the box denote the 
 25^th^ and 75^th^ percentiles. 
 The whiskers denote the most extreme data points that were no more than 1.5 
 times the interquartile range (i.e., height of the box). 
 Response proportions at week [peak] <!-- peak time point --> are displayed above
-durability box plots for each experimental group and pseudovirus with 
-responers at week [peak] <!-- peak time point -->.
+fold-change box plots for each group and pseudovirus with 
+responders at week [peak] <!-- peak time point -->.
 
 <!--- If MB curves plotted, include the following. ---> 
-Magnitude-breadth (MB) curves characterize the magnitude (net ID~50~ titer) and 
+Magnitude-breadth (MB) curves characterize the magnitude (ID~50~ titer) and 
 breadth (number of isolates neutralized at a given titer) of each individual 
 plasma sample assayed against a panel of isolates [@Huang2009].  
 The x-axis represents the neutralization titer (t) and the y-axis represents 
@@ -59,13 +65,13 @@ the fraction of isolates with neutralization titers greater than t.
 In addition to the individual sample-specific curves, the group-specific curve 
 displays the average MB across all subjects in that group. 
 <!--- If AUC-MB calculated, include the following. ---> 
-The AUC-MB was calculated as the average of the log~10~ net ID~50~ titers over 
+The AUC-MB was calculated as the average of the log~10~ ID~50~ titers over 
 the panel of isolates, where titers that were below the limit-of-detection were 
 set to 10. AUC-MB values calculated from the MB curves were displayed as box 
-plots for each experimental group.
+plots for each group.
 
-To show response trends over time, line plots of log~10~ net ID~50~ titer 
-by pseudovirus and experimental group were plotted for each pseudovirus with
+To show response trends over time, line plots of log~10~ ID~50~ titer 
+by pseudovirus and group were plotted for each pseudovirus with
 samples at multiple time points.
 
 ## Statistical Tests
@@ -73,23 +79,23 @@ samples at multiple time points.
 <!-- The following is only a guide. Please refer to the SAP for specific 
 information on statistical tests. --> 
 
-Statistical tests were performed as pairwise tests between the experimental 
-groups at weeks <!-- Refer to the SAP for timepoints tested -->. 
+Statistical tests were performed as pairwise tests between the groups at weeks 
+<!-- Refer to the SAP for timepoints tested -->. 
 
-Pairwise comparisons of response rates between experimental groups for each 
+Pairwise comparisons of response rates between groups for each 
 pseudovirus were conducted using Barnard's exact test (two-sided, alpha = 0.05) 
 [@Lyderson2009], [@Suissa1985]. 
 
-Pairwise comparisons of response magnitudes (log~10~ net ID~50~ titers) were 
-made between experimental groups for each pseudovirus using the Wilcoxon 
+Pairwise comparisons of response magnitudes (log~10~ ID~50~ titers) were 
+made between groups for each pseudovirus using the Wilcoxon 
 rank-sum test (two-sided, alpha = 0.05).
 <!-- Check the SAP for details on inclusion criteria. -->
 Response magnitude tests included responders and non-responders (with truncated 
-net ID~50~ titer measurements). 
+ID~50~ titer measurements). 
 All magnitude tests required at least 3 responders in at least one of the groups 
 being compared.
 
-Pairwise comparisons of AUC-MB were made between experimental groups for the 
+Pairwise comparisons of AUC-MB were made between groups for the 
 global pseudovirus panel at week <!-- Add time point. --> using the Wilcoxon 
 rank-sum test (two-sided, alpha = 0.05). 
 AUC-MB tests included responders and non-responders (with truncated net ID~50~ 
@@ -97,18 +103,18 @@ titer measurements).
 
 Pairwise comparisons of the durability (fold-change) between 
 week <!-- peak time point --> and week <!-- durability time point -->
-were performed between experimental groups using the log-rank test 
+were performed between groups using the log-rank test 
 (two-sided, alpha = 0.05) with Wilcoxon-Mann-Whitney scores and interval 
 censoring for each pseudovirus (@Fay). 
 The method outlined by @Fay2012 maintains the type I error rate under 
 assessment-treatment dependence. 
-A fold-change was considered censored when the net ID~50~ titer value at the 
+A fold-change was considered censored when the ID~50~ titer value at the 
 durability time point was below the limit of detection. 
 The lower bound of the interval was set to 
 $\mathrm{log_{10}}$$\mathrm{(1/X_{\text{week [peak]}})}$ 
 and the upper bound of the interval was set to 
 $\mathrm{log_{10}}$$\mathrm{(20/X_{\text{week [peak]}})}$ 
-for censored values, where X represents net ID~50~ titer and 20 is the limit
+for censored values, where X represents ID~50~ titer and 20 is the limit
 of detection for the NAb assay.
 Tests were only performed for pairs of groups where both groups had at least 3 
 positive responders at week <!-- peak time point -->, and the median fold-change 

--- a/man/use_visc_report.Rd
+++ b/man/use_visc_report.Rd
@@ -7,7 +7,7 @@
 use_visc_report(
   report_name = "PT-Report",
   path = ".",
-  report_type = c("empty", "generic", "bama")
+  report_type = c("empty", "generic", "bama", "nab")
 )
 }
 \arguments{


### PR DESCRIPTION
Thanks for reviewing the NAb template draft. 

To create this draft, I reviewed:
* [Dubois846 NAb report](https://github.com/FredHutch/Dubois846Analysis/blob/nab-pt-report/NAb-pt-report/NAb-pt-report.pdf)
* [Caskey820 NAb report](https://github.com/FredHutch/Caskey820Analysis/blob/master/NAB/Caskey_NAb_Interim_Report/Caskey820_Blinded_Interim_NAb_PT_Report.pdf)
* McElrath [708](https://github.com/FredHutch/McElrath708Analysis/blob/master/NAb/NAb_PT_Report/NAb_PT_Report.pdf) and [749](https://github.com/FredHutch/McElrath749Analysis/blob/master/NAb/NAb_pt_report.pdf) NAb reports
* [Gallo 477 NAb report](https://github.com/FredHutch/Gallo477Analysis/blob/master/NAb/Interim_analyses/Cohort1/PT_NAb_Gallo477_Cohort1/PT_NAb_Gallo477_Cohort1.pdf)
* HVTN reports package [NAb memo template](https://github.com/FredHutch/hvtnReports/blob/master/inst/memo_templates/memo_nab.Rmd)
* [VISC-Assay-Methods](https://github.com/FredHutch/VISC-Assay-Methods) repo

Some notes:
* I used "net ID_50_ titer" (subscript does not work in Github comments!) consistently to refer to the statistical endpoint. This hasn't been consistent in past reports. We've used a combination of SLV-subtracted ID50 titer, ID50 titers, NAb titers, etc. to refer to the subtracted endpoint. 
* There's a note to check for SLV-subtraction in the lab study plan. 
* HVTN uses "IC50".
* I moved the MB description to the graphical analysis and adopted the language from HTVN reports which I thought was easier to understand.

Can you please complete this review by COB 1/20? Let me know if you need additional time. I may schedule a working meeting for us to review edits like we did with BAMA.

Thank you!