### PR TITLE
Add check and guidance on PT report naming convention

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -109,7 +109,11 @@ use_bib <- function(study_name) {
 #'
 #' @examples
 #' \dontrun{
-#' use_visc_report(report_name = "BAMA-PT-Report", path = "bama", report_type = "bama")
+#' use_visc_report(
+#'   report_name = "McElrath708_BAMA_PT_Report_blinded",
+#'   path = "BAMA",
+#'   report_type = "bama"
+#'   )
 #' }
 use_visc_report <- function(report_name = "PT-Report",
                             path = ".",
@@ -130,6 +134,9 @@ use_visc_report <- function(report_name = "PT-Report",
       )
 
   } else {
+
+    challenge_visc_report(report_name)
+
     rmarkdown::draft(
       file = file.path(path, report_name),
       template = "visc_report",
@@ -144,6 +151,23 @@ use_visc_report <- function(report_name = "PT-Report",
   }
 
 
+}
+
+challenge_visc_report <- function(report_name) {
+
+  continue <- usethis::ui_yeah("
+    Creating a new VISC PT Report called {report_name}.
+    At VISC, we use a naming convention for PT reports:
+    'VDCnnn_assay_PT_Report_statusifapplicable'
+    where 'statusifapplicable' distinguishes blinded reports,
+    HIV status, or something that distinguishes a type/subset
+    of a report.
+    'VDC' is the PI name and 'nnn' is the study number.
+    Would you like to continue?")
+
+  if (!continue) {
+    usethis::ui_stop("Stopping `use_visc_report()`")
+  }
 }
 
 #' Use template files for methods sections in PT reports

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,7 +76,7 @@ Use a VISC Report:
 
 ```{r eval=FALSE}
 use_visc_report(
-  report_name = "BAMA-PT-Report", # the name of the report file
+  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", or "bama" 
 )

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Use a VISC Report:
 
 ``` r
 use_visc_report(
-  report_name = "BAMA-PT-Report", # the name of the report file
+  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", or "bama" 
 )

--- a/man/use_visc_report.Rd
+++ b/man/use_visc_report.Rd
@@ -22,6 +22,10 @@ Use a VISC Report Template
 }
 \examples{
 \dontrun{
-use_visc_report(report_name = "BAMA-PT-Report", path = "bama", report_type = "bama")
+use_visc_report(
+  report_name = "McElrath708_BAMA_PT_Report_blinded",
+  path = "BAMA",
+  report_type = "bama"
+  )
 }
 }

--- a/vignettes/using_pdf_and_word_template.Rmd
+++ b/vignettes/using_pdf_and_word_template.Rmd
@@ -21,7 +21,7 @@ To use a VISC report template, run:
 
 ```{r eval=FALSE}
 use_visc_report(
-  report_name = "BAMA-PT-Report", # the name of the report file
+  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", or "bama" 
 )
@@ -32,7 +32,7 @@ up the following structure in the existing `BAMA/` directory:
 
 ```
 |- BAMA/
-|  +- BAMA-PT-Report/              
+|  +- VDCnnn_BAMA_PT_Report_statusifapplicable/              
 |     +- BAMA-PT-Report.Rmd             # VISC report template
 |     +- methods/                       # folder with "child" .Rmd documents
 |       +- biological-endpoints.Rmd


### PR DESCRIPTION
Update package with report naming guidance.

A message will pop up when users run `use_visc_report()` with a reminder of VISC naming convention:

`VDCnnn_assay_PT_Report_statusifapplicable`

Users must confirm before template is created.