### PR TITLE
Update git_obj_compare_fun.R

### DIFF
--- a/R/git_obj_compare_fun.R
+++ b/R/git_obj_compare_fun.R
@@ -1,6 +1,6 @@
 
 ### The goal of the function is to compare 2 data objects from different commits.
-# dataObject can either be selected from choices, typed in as text, or rda object can be used as well
+# data_object can either be selected from choices, typed in as text, or rda object can be used as well
 # SHA1 corresponds to commit of data object that will be compared. SHA1 can either be SHA or commit short form or long form. SHA1 can be null (useful for situations where pdata has just been updated and comparison is being done with previous version)
 # SHA2 can be NULL or have another commit. NULL is useful when you have a current pdata object loaded in workspace. non-null SHA2 is useful for when comparing 2 objects from different commits.
 # objects are compared through package {diffdf}.
@@ -10,10 +10,13 @@
 #' @param SHA1 first commit id
 #' @param SHA2 second commit id
 #' @return a list of:
-#' \item{
-#'
-#' }
-#' @importFrom git2r repository_head odb_blobs remote_url checkout stash status
+#' \item{repo}{The remote repository}
+#' \item{branch}{The current branch}
+#' \item{SHA_1}{First commit ID}
+#' \item{SHA_2}{Second commit ID}
+#' \item{object_name}{Name of the object}
+#' \item{differences}{Output of diffdf}
+#' @importFrom git2r repository_head odb_blobs remote_url checkout stash status stash_pop
 #' @importFrom diffdf diffdf
 #' @details working directory must be pointed to repo clone
 #' @examples
@@ -24,36 +27,35 @@ object_compare <-
   function(data_object = NULL,
            SHA1 = NULL,
            SHA2 = NULL) {
-
+    
     repo_info <- list(
       "repo" = NULL,
       "branch" = NULL,
-      "SHA1" = NULL,
-      "SHA2" = NULL,
+      "SHA_1" = NULL,
+      "SHA_2" = NULL,
       "object_name" = NULL,
-      "differences" = NULL #ideally I'd like the function to output the warning message, but will save here for now
+      "differences" = NULL 
     )
-
+    
     ## get branch name
-
+    
     git_branch <- repository_head(".")$name
-
+    
     repo_info$branch <- git_branch
-
+    
     ## get all rda objects
     object_names <-
       sort(unique(subset(
         odb_blobs(), grepl(".rda", name)
       )$name))
-
-
-
+    
+    
     ### Give choice to select object name
     if (is.null(data_object)) {
-      for (i in 1:length(object_names)) {
-        cat(sprintf("%d. %s\n", i, object_names[i]))
-      }
-
+      
+      cat(do.call(paste, c(sprintf("%d. %s", seq_along(object_names), object_names), list(sep = '\n'))), sep = '\n')
+      
+      
       object_selection <- readline("Enter # for pdata: ")
       object_selection <-
         tryCatch(
@@ -61,139 +63,145 @@ object_compare <-
           warning = function(c)
             "integer typed incorrectly."
         )
-
+      
       ## if branch selection out of bounds then return selection menu
       while (!any(object_selection == 1:length(object_names))) {
         object_selection <- readline("Enter # for pdata: ")
       }
-
+      
       pdata_object <- object_names[object_selection]
     } else if (class(data_object) == "character") {
       ## if user types in object name then filter to that selection
-      pdata_object <- grep(data_object, object_names, value = TRUE)
-
-
-
+      pdata_object <- grep(data_object, object_names, value = TRUE, ignore.case = TRUE)
+      
+      
+      
     } else if (class(data_object) == "data.frame") {
-    #if user inserts object then don't ask for selection input
+      #if user inserts object then don't ask for selection input
       data_object_1 <- data_object
       pdata_object_1 <- deparse(substitute(data_object))
       pdata_object <- paste0(pdata_object_1, ".rda")
     }
-
+    
     if (length(pdata_object) < 1) {
       stop("Object not found. Input should contain text found in pdata object name.")
     }
-
+    
     # store object name in list
     repo_info$object_name <- pdata_object
-
-
+    
+    
     # get commit information on the object
     files <- subset(odb_blobs(), name == pdata_object)
     ## get SHAs to compare
     ### IF SHA1 NULL then grab most recent pdata commit
     if (is.null(SHA1)) {
       get_first <- sort(files$when, decreasing = TRUE)[1]
-
-      SHA1 <- unique(subset(files, when == get_first)$commit)
-
+      
+      SHA_1 <- unique(subset(files, when == get_first)$commit)
+      
     } else if (!is.null(SHA1)) {
       ## if SHA1 isn't null then grab full SHA text
-      SHA1 <-
+      SHA_1 <-
         unique(subset(odb_blobs(), grepl(SHA1, sha) |
                         grepl(SHA1, commit))$commit)
-
-      if (length(SHA1) < 1) {
+      
+      if (length(SHA_1) < 1) {
         stop("Commit not found. Input should be a commit or SHA.")
       }
-
+      
     }
-
+    
     ## store SHA1 in list
-    repo_info$SHA1 <- SHA1
-
+    repo_info$SHA_1 <- SHA_1
+    
     ## if comparing object from two different commits, insert SHA2
     if (!is.null(SHA2)) {
-      SHA2 <-
+      SHA_2 <-
         unique(subset(odb_blobs(), grepl(SHA2, sha) |
                         grepl(SHA2, commit))$commit)
-
+      
     } else if (is.null(SHA2)) {
       #if not comparing SHA2 then make blank
-      SHA2 <- ""
-
+      SHA_2 <- ""
+      
     }
     # store SHA2 in list
-    repo_info$SHA2 <- SHA2
-
-
+    repo_info$SHA_2 <- SHA_2
+    
+    
     ## Get repository remote url
-
+    
     repo <-
       ifelse(length(remote_url()) == 1, remote_url(), "")
-
+    
     # store repository remote url in list
     repo_info$repo <- repo
-
-
+    
+    
     ### checkout to SHA1 and store pdata object to compare
-    #TODO: stash files if needed
-
-    if (length(status(".")$unstaged) > 0) {
+    # stash files if needed
+    
+    if (!is.null(unlist(status()))) {
       stash_selection <- readline("Stash changes? [Y/N]: ")
-
+      
       if (stash_selection == 'Y') {
-        stash(".")
+        git_stash <- stash(".")
       } else if (stash_selection == 'N') {
         stop("Need to save or remove changes before checking out.")
       }
+    } else if (is.null(unlist(status()))) {
+      git_stash <- NULL
     }
-
-
-
+    
+    
+    
     data_file <- paste('data/', pdata_object, sep = "")
     # if SHA2 is null then assign checked-out object as object2
     if (is.null(SHA2)) {
-      checkout(".", SHA1)
-
-      load(file = dataFile)
-      data_object_2 <- pdata_object
-
-
-
-    } else if (!is.null(SHA2)) {
-      ## if SHA2 isn't null then assign SHA1 object as object1 and SHA2 object as object2
-      checkout(".", SHA1)
-      load(file = data_file)
-      data_object_1 <- get(gsub(".rda", "", pdata_object))
-
-
-      checkout(".", SHA2)
+      checkout(".", SHA_1)
+      
       load(file = data_file)
       data_object_2 <- get(gsub(".rda", "", pdata_object))
-
-
-
-      ## checkout to HEAD to go back to current branch state
-
-      checkout(".", git_branch)
-
-      ###TODO: check differences of data objects
-      differences <- diffdf(data_object_1, data_object_2)
-
-      ##TODO: fix below
-      withCallingHandlers(
-        diffdf(data_object_1, data_object_2),
-        warning = function(w)
-          print(w$message)
-      )
-
-      repo_info$differences <- differences
-      return(repo_info)
-
+      
+      
+      
+    } else if (!is.null(SHA2)) {
+      ## if SHA2 isn't null then assign SHA1 object as object1 and SHA2 object as object2
+      checkout(".", SHA_1)
+      load(file = data_file)
+      data_object_1 <- get(gsub(".rda", "", pdata_object))
+      
+      
+      checkout(".", SHA_2)
+      load(file = data_file)
+      data_object_2 <- get(gsub(".rda", "", pdata_object))
+      
     }
-}
+    
+    ## checkout to HEAD to go back to current branch state
+    
+    checkout(".", git_branch)
+    
+    ## stash pop 
+    if(!is.null(git_stash)){
+      stash_pop(git_stash)
+    }
+    
+    
+    ## check differences of data objects
+    
+    differences <- withCallingHandlers(
+      diffdf(data_object_1, data_object_2),
+      warning = function(w)
+        conditionMessage(w)
+    )
+    
+    repo_info$differences <- differences
+    return(repo_info)
+    
+    
+  }
 
 
 


### PR DESCRIPTION
Referencing PR #110 

> there is a mix of camel case vs period.separated, and I am under the impression that team prefers to use snake_case to better align with tidyverse usage, reference: https://style.tidyverse.org/syntax.html

Code has been updated to snake_case in this PR.

> how should we handle data object syntax? can this function handle both "Lusso847_nab" and "nab" (auto populating the package name)? will we need to compare data objects not in a VISC data package?

The function is case-insensitive and can handle any version of names (Lusso847_nab vs nab) as long as a match can be found using `grep()` 

> for the stash activity, can we name this so as not to interfere with existing stash? do we pop this stash so as not to introduce a change to the user system?

Stash has been saved as git_stash, and a stash_pop will be applied to drop this recent stash

> what is the benefit of using diffdf vs dplyr::all_equal or testthat::expect_equal? is this documented well?

diffdf allows for detailed comparison between two dataframes. One key difference between dplyr::all_equal() and diffdf::diffdf() is that diffdf returns differences between the data. This output might be useful to see detailed information on differences. Would this be something useful in a common scenario? Some options are 
1. We output these differences
2. We output only if there is a difference/no difference (such as with `dplyr::all_equal()` and `testthat::expect_equal`
3. We create an option where the user can select either or

https://cloud.r-project.org/web/packages/diffdf/vignettes/diffdf-basic.html