### PR TITLE
Fix double section numbering in word doc template

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -313,5 +313,6 @@ visc_word_document <- function(toc = TRUE,
     fig_caption = fig_caption,
     keep_md = keep_md,
     reference_docx = word_style_path,
+    number_sections = FALSE,
     ...)
 }


### PR DESCRIPTION
Addresses issue with Word document section numbering happening twice (see https://github.com/FredHutch/VISCtemplates/issues/67)