### PR TITLE
Fix latex template issue with etex and \reserveinserts

### DIFF
--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -1,6 +1,6 @@
 \documentclass[11pt]{article}
-\usepackage{etex}
-\reserveinserts{28}
+%\usepackage{etex}
+%\reserveinserts{28}
 \usepackage{lastpage}
 \usepackage[hmargin=2cm, top=2.7cm, bottom=3.5cm, footskip=0.5cm]{geometry}
 \usepackage{url}


### PR DESCRIPTION
@lemireg and I have both run into issues with the etex package and its \reserveinserts command used in template.tex causing reports to fail to compile. The etex package is apparently no longer needed (recent version of latex incorporate most of its functionality), so this hotfix comments out the relevant lines in template.tex and resolves the issue (it has been tested by me, @lemireg, and @mayerbry on our respective systems).