### PR TITLE
Respect existing repos option

### DIFF
--- a/R/report_template.R
+++ b/R/report_template.R
@@ -8,17 +8,19 @@
 #' @examples
 #' \dontrun{load_install_cran_packages(c("tidyr", "dplyr"))}
 install_load_cran_packages <- function(packages) {
+  installed_packages <- rownames(utils::installed.packages())
   lapply(packages, FUN = function(package) {
-    if (!require(package, character.only = TRUE)) {
+    if (! package %in% installed_packages) {
       if (package %in% c("VISCfunctions", "VISCtemplates")) {
         stop(paste0("The package ", package, " must be installed through GitHub:
                   https://github.com/FredHutch/", package, ".git"))
       } else {
-        utils::install.packages(package, repos = "http://cran.us.r-project.org")
+        utils::install.packages(package)
       }
     }
     library(package, character.only = TRUE)
   })
+  invisible(NULL)
 }
 
 #' Check pandoc version

--- a/R/report_template.R
+++ b/R/report_template.R
@@ -16,6 +16,15 @@ install_load_cran_packages <- function(packages) {
                   https://github.com/FredHutch/", package, ".git"))
       } else {
         utils::install.packages(package)
+        # install.packages() installs packages from the repository identified in
+        # options('repos'), which is CRAN by default. To change this
+        # setting, edit your .Rprofile. To view a list of available CRAN
+        # mirrors, use command getCRANmirrors(). As of 2024, the most common
+        # settings are to use https://cloud.r-project.org which auto-redirects
+        # to CRAN mirrors worldwide, or to set up the Posit Public Package
+        # Manager <https://packagemanager.posit.co/client/#/repos/cran/setup>,
+        # especially for fast install of binary CRAN packages on Linux.
+        # See also: <https://github.com/FredHutch/VISCtemplates/pull/163>
       }
     }
     library(package, character.only = TRUE)


### PR DESCRIPTION
By default and when otherwise configured properly, R should not require specifying `repos` in `install.packages()` because `getOption('repos')` is used automatically.

The old behavior was to hardcode `http://cran.us.r-project.org`. This can be an annoyance. For example, it's common on Linux to set up custom repos in `.Rprofile` to install binary packages from Posit Public Package Manager, to greatly reduce install time for packages. During some `VISCtemplates` testing that called `install_load_cran_packages()`, packages got installed from source instead due to the hardcode, which took a lot longer.

The new behavior is to respect the existing `repos` option to follow [best practices](https://r-pkgs.org/code.html#sec-code-r-landscape).

I also tweaked the way it looks for installed packages to avoid a warning when the package is not found, and have it returning invisibly instead of printing out the list of packages installed.