### PR TITLE
VISCfunctions to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
     stringr,
     usethis,
     glue,
-    utils
+    utils,
+    VISCfunctions
 Encoding: UTF-8
 URL: https://github.com/FredHutch/VISCtemplates
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
@@ -37,5 +38,7 @@ Suggests:
     knitr,
     testthat (>= 3.0.0),
     withr
+Remotes:
+    FredHutch/VISCfunctions
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,0 +1,10 @@
+# This function exists solely to avoid R CMD check warnings due to VISCfunctions
+# being in Imports but only being used in Rmd template, not in actual package
+# code. See:
+# https://r-pkgs.org/dependencies-in-practice.html#how-to-not-use-a-package-in-imports
+# We want VISCfunctions to be in Imports so that it will get auto-installed
+# whenever someone installs VISCtemplates from github.
+ignore_unused_imports <- function() {
+  VISCfunctions::get_session_info
+  invisible(NULL)
+}


### PR DESCRIPTION
I was doing some VISCtemplates testing on my personal laptop, roughly this:

```
create_visc_project("~/repos/VDC123Analysis")
use_visc_report(report_name = "Example-PT-Report", report_type = "generic")
# knit Example-PT-Report/Example-PT-Report.Rmd
```

I got this error when trying to knit Example-PT-Report.Rmd, because VISCfunctions was not already installed:

```
processing file: Example-PT-Report.Rmd
                                                                                                                                 
Error in `library()`:
! there is no package called 'VISCfunctions'
Backtrace:
 1. base::library(VISCfunctions)

Quitting from lines 49-83 [package-loading-and-options] (Example-PT-Report.Rmd)
Execution halted
```

Being able to knit a generic report from the template is fairly central to VISCtemplates, so this PR adds VISCfunctions to the Imports for the VISCtemplates package.  I include a work-around to avoid R CMD check warnings. With the change, VISCfunctions will get auto-installed whenever someone installs VISCtemplates from GitHub, which should reduce friction using VISCtemplates.