### PR TITLE
Speed up skeleton action via binary R pkg installations

### DIFF
--- a/.github/workflows/render-skeleton-rmd.yaml
+++ b/.github/workflows/render-skeleton-rmd.yaml
@@ -12,20 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    
+
     steps:
 
       - name: Checkout VISCtemplates repo
         uses: actions/checkout@v4
-    
+
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up tinytex
         uses: r-lib/actions/setup-tinytex@v2
-      
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - name: Install R packages from VISCtemplates DESCRIPTION file and any others needed
         uses: r-lib/actions/setup-r-dependencies@v2
@@ -35,7 +37,7 @@ jobs:
             any::devtools
             any::conflicted
             any::tidyverse
-      
+
       - name: Install VISCfunctions from GitHub
         run: |
           Rscript -e 'remotes::install_github("FredHutch/VISCfunctions")'


### PR DESCRIPTION
Addresses #165.

Looks like this improves install time of R package dependencies on the action 10x from about 20 min to about 2 min. This uses the same recommended source for binary R packages as what [we already use](https://github.com/FredHutch/VISCtemplates/blob/86e2f15c6d2e484e482e08b5d992490acb5c90e2/.github/workflows/R-CMD-check.yaml#L40) in the R CMD check yaml workflow and as generated by `usethis::use_github_action()`.

Old: https://github.com/FredHutch/VISCtemplates/actions/runs/9455206517/job/26044449900
New: https://github.com/FredHutch/VISCtemplates/actions/runs/9602856269/job/26484650844?pr=166