### PR TITLE
Add GitHub Actions runner to mimic statsrv

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,16 +58,10 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Preinstall remotes on statsrv
-          if: ${{ matrix.config.r == '4.0.4' }}
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          packages: |
-            any::remotes
-
       - name: Preinstall statsrv Hmisc version
           if: ${{ matrix.config.r == '4.0.4' }}
         run: |
+          Rscript -e 'install.packages("remotes")'
           Rscript -e 'remotes::install_version("Hmisc", "4.5-0")'
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '4.0.4', pandoc-version: '2.11.4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +33,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
+        with:
+          pandoc-version: ${{ matrix.config.pandoc-version }}
 
       - name: Set up tinytex
         uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,6 +65,7 @@ jobs:
           R -q -e 'utils::install.packages("htmlTable")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
+          R -q -e 'utils::install.packages("rcmdcheck")'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         if: ${{ matrix.config.r != '4.0.4' }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,7 +67,7 @@ jobs:
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-          if: ${{ matrix.config.r != '4.0.4' }}
+        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           extra-packages: any::rcmdcheck
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,16 +58,15 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Preinstall statsrv Hmisc version
-          if: ${{ matrix.config.r == '4.0.4' }}
-        run: |
-          Rscript -e 'install.packages("remotes")'
-          Rscript -e 'remotes::install_version("Hmisc", "4.5-0")'
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
+
+      - name: Install statsrv Hmisc version
+        if: ${{ matrix.config.r == '4.0.4' }}
+        run: |
+          Rscript -e 'remotes::install_version("Hmisc", "4.5-0")'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,16 +58,16 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Install statsrv Hmisc version
+        if: ${{ matrix.config.r == '4.0.4' }}
+        run: |
+          R -q -e 'utils::install.packages("remotes")'
+          R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
-        continue-on-error: true
-
-      - name: Install statsrv Hmisc version
-        if: ${{ matrix.config.r == '4.0.4' }}
-        run: |
-          Rscript -e 'remotes::install_version("Hmisc", "4.5-0")'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,9 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup statsrv pandoc
+        if: ${{ matrix.config.r == '4.0.4' }}
       - uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: ${{ matrix.config.pandoc-version }}
+
+      - name: Setup default pandoc
+        if: ${{ matrix.config.r != '4.0.4' }}
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up tinytex
         uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Setup statsrv pandoc
         if: ${{ matrix.config.r == '4.0.4' }}
-      - uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: ${{ matrix.config.pandoc-version }}
 
       - name: Setup default pandoc
         if: ${{ matrix.config.r != '4.0.4' }}
-      - uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up tinytex
         uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,6 +58,17 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Preinstall remotes on statsrv
+          if: ${{ matrix.config.r == '4.0.4' }}
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: any::remotes
+
+      - name: Preinstall statsrv Hmisc version
+          if: ${{ matrix.config.r == '4.0.4' }}
+        run: |
+          Rscript -e 'remotes::install_version("Hmisc", "4.5-0")'
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,7 +62,7 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
           R -q -e 'utils::install.packages("remotes")'
-          R -q -e 'remotes::install_version("htmlTable", "2.4.2")'
+          R -q -e 'utils::install.packages("htmlTable")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,7 +62,8 @@ jobs:
           if: ${{ matrix.config.r == '4.0.4' }}
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: any::remotes
+          packages: |
+            any::remotes
 
       - name: Preinstall statsrv Hmisc version
           if: ${{ matrix.config.r == '4.0.4' }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,13 +58,16 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install statsrv Hmisc version
+      - name: Install statsrv packages
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
           R -q -e 'utils::install.packages("remotes")'
+          R -q -e 'remotes::install_version("htmlTable", "2.4.2")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
+          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+          if: ${{ matrix.config.r != '4.0.4' }}
         with:
           extra-packages: any::rcmdcheck
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,6 +66,7 @@ jobs:
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
           R -q -e 'utils::install.packages("rcmdcheck")'
+          R -q -e 'utils::install.packages("tidyverse")'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         if: ${{ matrix.config.r != '4.0.4' }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+        continue-on-error: true
 
       - name: Install statsrv Hmisc version
         if: ${{ matrix.config.r == '4.0.4' }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,8 +62,8 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
           R -q -e 'utils::install.packages("remotes")'
-          R -q -e 'utils::install.packages("htmlTable")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
           R -q -e 'utils::install.packages("rcmdcheck")'
 


### PR DESCRIPTION
This adds a CI runner to match the R version (4.0.4) and pandoc version (2.11.4) on `statsrv`.

This is behaving as intended in that all reports successfully knit here on the develop branch, while the other runners with newer pandoc fail to knit. I expect the opposite will be true once this runner gets merged up into the other branch with Kellie's fix, which fixes knitting on new pandoc but breaks knitting on old pandoc.