### PR TITLE
Fix warnings during knitting

### DIFF
--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -48,7 +48,11 @@ install_load_cran_packages(packages_needed)
 # knitr options
 opts_chunk$set(cache = FALSE, message = TRUE, warning = TRUE, echo = FALSE, 
                dev = c("png", "pdf"), dpi = 200, out.width = '100%', 
-               out.extra = '', fig.align = "center", fig.pos = "H")
+               out.extra = '', fig.pos = "H")
+# fig.align argument is not supported in Word (align in template docx)
+if (knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex'){
+  opts_chunk$set(fig.align = "center")
+}
 
 # NA's will be blank in tables
 options(knitr.kable.NA = '')

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -64,7 +64,11 @@ my_data_package_lib <- "/Volumes/kmacphee/RLib/" # UPDATE WITH YOUR DATA PACKAGE
 # knitr options
 opts_chunk$set(cache = FALSE, message = TRUE, warning = TRUE, echo = FALSE, 
                dev = c("png", "pdf"), dpi = 200, out.width = "100%", 
-               out.extra = "", fig.align = "center", fig.pos = "H")
+               out.extra = "", fig.pos = "H")
+# fig.align argument is not supported in Word (align in template docx)
+if (knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex'){
+  opts_chunk$set(fig.align = "center")
+}
 
 # NA's will be blank in tables
 options(knitr.kable.NA = '')

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -162,7 +162,7 @@ presents neutralization data to Tier 1A and Tier 2 versions of the vaccine strai
 assessed by the TZM-bl assay. Additionally this report summarizes epitope mapping 
 isolate pairs.")
 
-Reference test (@Huang:2013fl).
+Reference test [@Huang:2013fl].
 
 <!-- Frequently used citations are included in the `docs/bibliography.bib` file created with `VISCtemplates::create_visc_project()`. If `docs/bibliography.bib` doesn't exist, it will be created when you knit this document. -->
 

--- a/inst/templates/methods-bama/bama-lab-methods.Rmd
+++ b/inst/templates/methods-bama/bama-lab-methods.Rmd
@@ -10,7 +10,7 @@ Please edit that file. -->
 
 Serum HIV-1 [IgG/IgA] responses against [# antigens] were measured on a Bio-Plex 
 instrument (Bio-Rad) using a standardized custom HIV-1 Luminex assay 
-(@tomaras2008). 
+[@tomaras2008].
 The readout is background-subtracted median fluorescent intensity (MFI), 
 where background refers to the antigen-specific plate-level control 
 (i.e., a blank well containing antigen-conjugated beads run on each plate). 

--- a/inst/templates/methods-bama/bama-statistical-methods.Rmd
+++ b/inst/templates/methods-bama/bama-statistical-methods.Rmd
@@ -88,7 +88,7 @@ Net MFI values were truncated at 1 for AUC calculations.
 
 <!-- if you have all antigens from an ARP (antigen reagent project) panel -->
 
-Individual-specific and group-averaged magnitude-breadth (MB) curves (@Huang2009-ao) 
+Individual-specific and group-averaged magnitude-breadth (MB) curves [@Huang2009-ao]
 characterized the 
 magnitude (binding antibody MFI\*) and 
 breadth (number of antigens with positive response at a given value of net MFI that is greater than 100) 
@@ -157,10 +157,10 @@ at any time point.
 ## Statistical Tests
 
 To assess if the treatment groups had different response rates than control, 
-each group was compared to control using Barnard’s exact test (two-sided, alpha = 0.05) 
-for each isotype and antigen (@Suissa1985 and @Lyderson2009). 
+each group was compared to control using Barnard's exact test (two-sided, alpha = 0.05)
+for each isotype and antigen [@Suissa1985 and @Lyderson2009].
 If there were any significant differences from control, 
-pairwise treatment group tests were performed using Barnard’s exact test 
+pairwise treatment group tests were performed using Barnard's exact test
 (two-sided, alpha = 0.05).
 
 Pairwise comparisons of response magnitude ([AUTC, net MFI]) between study groups 
@@ -171,7 +171,7 @@ positive responders in each treatment group.
 Pairwise comparisons of net MFI durability (fold-change) between peak and 
 durability were performed between treatment groups using the log-rank test 
 (two-sided, alpha = 0.05) with Wilcoxon-Mann-Whitney scores and interval 
-censoring for each antigen (@Fay2012). 
+censoring for each antigen [@Fay2012].
 The method outlined by @Fay2012 maintains the type I error rate under 
 assessment-treatment dependence. 
 A fold-change was considered censored when the net MFI value at the durability 

--- a/inst/templates/methods-bama/bama-statistical-methods.Rmd
+++ b/inst/templates/methods-bama/bama-statistical-methods.Rmd
@@ -145,8 +145,7 @@ Response proportions were displayed for each group at week [xx, peak].
 
 Individual-specific and group-average magnitude-breadth (MB) curves were plotted 
 to display the breadth of binding antibody activities. 
-[if applicable] MB curves were stratified by ARP panels (i.e., gp140, gp120 and V1V2) 
-(Table `r VISCtemplates::insert_ref("tab:sample-size")`).
+[if applicable] MB curves were stratified by ARP panels (i.e., gp140, gp120 and V1V2).
 
 Line plots were used to display the trend and the variability of the group
 median net MFI or AUTC over time by antigen. 

--- a/inst/templates/methods-nab/nab-statistical-methods.Rmd
+++ b/inst/templates/methods-nab/nab-statistical-methods.Rmd
@@ -59,7 +59,7 @@ responders at week [peak] <!-- peak time point -->.
 <!--- If MB curves plotted, include the following. ---> 
 Magnitude-breadth (MB) curves characterize the magnitude (ID~50~ titer) and 
 breadth (number of isolates neutralized at a given titer) of each individual 
-plasma sample assayed against a panel of isolates [@Huang2009].  
+plasma sample assayed against a panel of isolates [@Huang2009-ao].
 The x-axis represents the neutralization titer (t) and the y-axis represents 
 the fraction of isolates with neutralization titers greater than t.  
 In addition to the individual sample-specific curves, the group-specific curve 
@@ -105,7 +105,7 @@ Pairwise comparisons of the durability (fold-change) between
 week <!-- peak time point --> and week <!-- durability time point -->
 were performed between groups using the log-rank test 
 (two-sided, alpha = 0.05) with Wilcoxon-Mann-Whitney scores and interval 
-censoring for each pseudovirus (@Fay). 
+censoring for each pseudovirus [@Fay2012].
 The method outlined by @Fay2012 maintains the type I error rate under 
 assessment-treatment dependence. 
 A fold-change was considered censored when the ID~50~ titer value at the 


### PR DESCRIPTION
Resolves #174.
- fig.align = 'center' only works with PDF output and is now conditional on that. Aligning figures in DOCX [will need to be done via the DOCX template](https://github.com/yihui/knitr/issues/1784#issuecomment-563171527)
- removed apparently outdated reference after consulting with Alicia
- update reference handles causing references not found warnings
- fix some references brackets syntax and non-ascii characters

All 60 unit tests now pass with no R warnings on all CI platforms.