### PR TITLE
Avoid forcing 3 objects into the user's .GlobalEnv

### DIFF
--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -69,7 +69,7 @@ theme_set(visc_theme)
 
 # Set group colors for this example.
 # If you have group colors already in your project:
-# source(rprojroot::find_rstudio_root_file("docs", "group-colors.R"))
+# source(rprojroot::find_rstudio_root_file("docs", "group-colors.R"), local = TRUE)
 group_colors <- c(
   `1` = "#D92321",
   `2` = "#1749FF",

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -85,7 +85,7 @@ theme_set(visc_theme)
 
 # Set group colors for this example.
 # If you have group colors already in your project:
-# source(rprojroot::find_rstudio_root_file("R", "group_colors.R"))
+# source(rprojroot::find_rstudio_root_file("R", "group_colors.R"), local = TRUE)
 group_colors <- c(
   `1` = "#D92321",
   `2` = "#1749FF",

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -123,7 +123,7 @@ remotes::install_git(file.path('cavd', 'Studies', 'cvdNNN', 'pdata', 'VDCNNN.git
 
 ```{r data-processing}
 # For this template use VISCfunction example data
-data(exampleData_ICS)
+data('exampleData_ICS', package = 'VISCfunctions', envir = environment())
 
 ICS_adata <- exampleData_ICS %>% 
   filter(Population == "IFNg" & Group != 3)
@@ -152,7 +152,7 @@ be used across PT reports for the protocol. -->
 <!-- Also include the study schema here. -->
 
 ```{r study-schema, results="asis", warning=kable_warnings}
-source(rprojroot::find_rstudio_root_file("R", "study_schema.R"))
+source(rprojroot::find_rstudio_root_file("R", "study_schema.R"), local = TRUE)
 study_schema()
 ```
 

--- a/inst/templates/group_colors.R
+++ b/inst/templates/group_colors.R
@@ -8,7 +8,7 @@ group_colors <- c(
 )
 
 # To source these group colors in your Rmarkdown report:
-#  source("R/group-colors.R")
+#  source("R/group-colors.R", local = TRUE)
 
 # In ggplot2, you can set colors manually with:
 #  scale_color_manual(values = group_colors)

--- a/inst/templates/study_schema.R
+++ b/inst/templates/study_schema.R
@@ -1,7 +1,7 @@
 #' Study Schema for {{ study_name }}
 #'
 #' To source the study schema in a chunk in your Rmarkdown report:
-#' source("R/study_schema.R")
+#' source("R/study_schema.R", local = TRUE)
 #'
 #' @param caption caption for the study schema table
 #'

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -43,9 +43,8 @@ test_knit_report <- function(report_type, outfile_ext){
                           quiet = TRUE,
                           clean = FALSE)
       )
-      # push this variable out of the local() block
-      outfile_sans_ext <<- file.path(temp_dir, report_name, report_name)
     })
+    outfile_sans_ext <- file.path(temp_dir, report_name, report_name)
     expect_true(
       file.exists(paste0(outfile_sans_ext, '.', outfile_ext))
     )

--- a/vignettes/using_pdf_and_word_template.Rmd
+++ b/vignettes/using_pdf_and_word_template.Rmd
@@ -91,7 +91,6 @@ You can use this as a simple inline code: `` `r knitr::inline_expr("insert_break
 
 *  For referencing papers, simply use the @ symbol before bib file reference (i.e. `@Huang:2013fl`).
 
-
 ### Tables
 
 * Only output one table per code chunk.
@@ -112,3 +111,10 @@ You can use this as a simple inline code: `` `r knitr::inline_expr("insert_break
 
 * When using `VISCfunctions::pretty_pvalues()` make sure to use `output_type = output_type`,  `bold  = pandoc_markup`, and `italic = pandoc_markup`. This will give the appropriate markup depending on PDF or Word output.
 
+### Sourcing external R scripts
+
+* When using the `source()` function for external R scripts, use its `local = TRUE` argument. This will ensure that the objects created are placed in your Rmd's environment, rather than your global environment, which is a safer practice.
+
+### Loading external data
+
+* When using the `data()` function to load external data (e.g. from another package), specify `environment = environment()`. This will ensure that the object is placed in your Rmd's environment, rather than your global environment, which is a safer practice. See the "Good practice" section in `?utils::data` for more info.


### PR DESCRIPTION
This is a bit nit-picky, but the other day when I had interrupted `devtools::test()` I noticed that these 3 objects had been written to my global environment in Rstudio, which is not what we want to be doing per [best practices](https://r-pkgs.org/testing-design.html#sec-testing-design-self-contained).

This PR reins in the scoping of these 3 objects to the environment in which they actually get used.

See also:
- 'Good Practice' section in `?utils::data()`
- `local` argument documentation in `?source()`