### PR TITLE
make R CMD check (including CI) fail on test warnings

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,4 @@
 library(testthat)
 library(VISCtemplates)
 
-test_check("VISCtemplates")
+test_check("VISCtemplates", stop_on_warning = TRUE)


### PR DESCRIPTION
Currently, if there is an unexpected R warning thrown during testthat (e.g. a knitting warning), the console will show the traceback and it will show up in the WARN column of the testthat summary output. This is all good, and it works across `devtools::test()`, `devtools::check()`, and on the CI checks.

However, on CI, testthat warning(s) can be hard to notice because there is a green check mark for the GitHub Action runner overall as long as there were no errors.

With #182 now completed, there are no warnings currently thrown in the tests. If a new warning pops up during a PR, I believe we want to notice it so that we can fix the code to avoid a bad warning or suppress an unimportant one.

This PR tells testthat to pass an error to R CMD check if there are any warnings in the WARN column in the summary output of testthat. This happens both during devtools::check() and on CI, and does not affect devtools::test(). Once the error is passed to R CMD check it will throw a red check mark for that CI runner. We'll be able to know there are no warnings or errors just by seeing that the check mark is green, and we'll know to investigate further if we see a red check mark.

If this ends up being too heavy-handed, we could always undo it later!