### PR TITLE
Fix insert_break() and replace with \newpage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,7 +55,7 @@ The new release number is bumped to 1.0.0 because this version implements the st
 
 * Changes to VISC Report (PDF & Word Output) template.
     + Example text updated.
-    + Functions defined in report are now exported functions from {VISCtemplates}. Use `insert_break()` to create a page break and `insert_ref()` to insert a reference to a table or figure.
+    + Functions defined in report are now exported functions from {VISCtemplates}. Use `insert_ref()` to insert a reference to a table or figure.
     + Vignette updated to reflect these changes. 
 
 

--- a/R/report_functions.R
+++ b/R/report_functions.R
@@ -81,20 +81,16 @@ insert_ref <- function(ref, section_name = NA) {
 }
 
 
-#' Insert a page break
+#' Insert a page break (deprecated)
 #'
-#' Use this function in an R Markdown document to insert a page break when you
-#' are knitting both PDF (Latex) and Word document reports.
+#' Do not use in new code. Use latex command
+#' \code{\\newpage} in your Rmd instead. This function is retained to not
+#' break old Rmd files created from previous templates.
 #'
-#' @return inserts a page break
+#' @return Inserts a page break (deprecated)
 #' @export
-#'
-#' @examples
-#' \dontrun{visc_break()}
 insert_break <- function() {
-  ifelse(knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex',
-         '\\clearpage',
-         '#####')
+  '\\newpage'
 }
 
 #' Insert references section header

--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -99,7 +99,7 @@ Add some text here
 
 Add some text here
 
-`r insert_break()` 
+\newpage
 
 # Reproducibility Software Information
 
@@ -116,7 +116,7 @@ kable(
   linesep = "", 
   caption = "Reproducibility software session information"
   ) %>% 
-  kable_styling(font_size = 10)
+  kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
@@ -126,9 +126,9 @@ kable(
   linesep = "", 
   caption = "Reproducibility software package version information"
   ) %>% 
-  kable_styling(font_size = 10)
+  kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
-`r insert_break()` 
+\newpage
 
 `r insert_references_section_header()`

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -129,7 +129,7 @@ ICS_adata <- exampleData_ICS %>%
   filter(Population == "IFNg" & Group != 3)
 ```
 
-`r insert_break()` 
+\newpage
 
 # Summary of Main Results
 
@@ -285,7 +285,7 @@ Consider breaking up the results section by objective or by statistical endpoint
 Make sure to include p-values and references to relevant tables and figures. 
 See Figure `r insert_ref("fig:example-plot")` and Table `r insert_ref("tab:example-tab")`. 
 
-`r insert_break()` 
+\newpage
 
 # Figures and Tables
 
@@ -331,7 +331,7 @@ ICS_adata %>%
   )
 ```
 
-`r insert_break()` 
+\newpage
 
 ```{r example-tab, results="asis", warning=kable_warnings}
 
@@ -365,7 +365,7 @@ magnitude_tab %>%
   footnote("SD: standard deviation.", threeparttable = TRUE)
 ```
 
-`r insert_break()`  
+\newpage
 
 ```{r Software-Session-Information, results="asis", message=FALSE, warning=kable_warnings}
 # load in rmarkdown to capture verison number
@@ -380,7 +380,7 @@ kable(
   linesep = "", 
   caption = "Reproducibility software session information"
   ) %>% 
-  kable_styling(font_size = 10)
+  kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
@@ -390,10 +390,10 @@ kable(
   linesep = "", 
   caption = "Reproducibility software package version information"
   ) %>% 
-  kable_styling(font_size = 10)
+  kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
-`r insert_break()` 
+\newpage
 
 # Acknowledgements
 

--- a/man/insert_break.Rd
+++ b/man/insert_break.Rd
@@ -2,17 +2,15 @@
 % Please edit documentation in R/report_functions.R
 \name{insert_break}
 \alias{insert_break}
-\title{Insert a page break}
+\title{Insert a page break (deprecated)}
 \usage{
 insert_break()
 }
 \value{
-inserts a page break
+Inserts a page break (deprecated)
 }
 \description{
-Use this function in an R Markdown document to insert a page break when you
-are knitting both PDF (Latex) and Word document reports.
-}
-\examples{
-\dontrun{visc_break()}
+Do not use in new code. Use latex command
+\code{\\newpage} in your Rmd instead. This function is retained to not
+break old Rmd files created from previous templates.
 }

--- a/vignettes/using_pdf_and_word_template.Rmd
+++ b/vignettes/using_pdf_and_word_template.Rmd
@@ -66,9 +66,7 @@ There are some new functions and coding conventions that help with knitting the 
 
 ### Page breaks
 
-* For page breaks use the `insert_break()` function. 
-You can use this as a simple inline code: `` `r knitr::inline_expr("insert_break()")` ``.
-    + `\clearpage` (from previous template) will not work on Word output.
+* For page breaks use `\newpage`.
     
 ### Referencing
 `


### PR DESCRIPTION
Fixes #162.

- Fixes `insert_break()` function to always use `\newpage`
- Document that `insert_break()` is now deprecated and instruct users to use `\newpage` in new code
- Replace instances of `insert_break()` in skeletons with `\newpage`
- Fix latex float positioning of reproducibility tables in skeletons