### PR TITLE
Tweak test order

### DIFF
--- a/tests/testthat/test-use_visc_report.R
+++ b/tests/testthat/test-use_visc_report.R
@@ -1,3 +1,21 @@
+test_that("use_visc_report() creates missing subdirectory", {
+  temp_dir <- withr::local_tempdir()
+  create_visc_project(temp_dir, interactive = FALSE)
+  local({
+    withr::local_dir(temp_dir)
+    report_name <- "Caskey820_BAMA_PT_Report"
+    path <- "BAMA"
+    expect_no_warning(
+      use_visc_report(
+        report_name, path = path, report_type = "bama", interactive = FALSE
+      )
+    )
+    expect_true(
+      file.exists(file.path(path, report_name, paste0(report_name, ".Rmd")))
+    )
+  })
+})
+
 # This will test knitting all template report types, both pdf and docx. What
 # happens with file snapshots varies a bit depending on the testing context:
 #
@@ -17,28 +35,12 @@
 # snapshots will be buried within a larger results artifact, but when all tests
 # succeed, they will be in a snapshots artifact. Hopefully soon this will be
 # changed to always have the latter behavior regardless of test success.
+#
+# This sets a custom test context(), so should go last in this test file
 local({
   for (report_type in c('generic', 'empty', 'bama', 'nab')){
     for (output_ext in c('pdf', 'docx')){
       test_knit_report(report_type, output_ext)
     }
   }
-})
-
-test_that("use_visc_report() creates missing subdirectory", {
-  temp_dir <- withr::local_tempdir()
-  create_visc_project(temp_dir, interactive = FALSE)
-  local({
-    withr::local_dir(temp_dir)
-    report_name <- "Caskey820_BAMA_PT_Report"
-    path <- "BAMA"
-    expect_no_warning(
-      use_visc_report(
-        report_name, path = path, report_type = "bama", interactive = FALSE
-      )
-    )
-    expect_true(
-      file.exists(file.path(path, report_name, paste0(report_name, ".Rmd")))
-    )
-  })
 })


### PR DESCRIPTION
The test knitting function sets custom test contexts, so the subdirectory tests that came after were getting labeled under the last knit test (8 total for test nab docx, when there were only 6). This PR re-orders that test file and adds a note to keep the knit tests last.

Old:
```
ℹ Testing VISCtemplates
✔ | F W  S  OK | Context
✔ |          6 | knit generic report pdf [4.7s]                                         
✔ |          6 | knit generic report docx [3.0s]                                        
✔ |          6 | knit empty report pdf [3.2s]                                           
✔ |          6 | knit empty report docx [2.7s]                                          
✔ |          6 | knit bama report pdf [5.8s]                                            
✔ |          6 | knit bama report docx [4.1s]                                           
✔ |          6 | knit nab report pdf [6.6s]                                             
✔ |          8 | knit nab report docx [4.8s]                                            
✔ |         10 | visc_load_pdata [7.8s]                                                 

```

New:
```
ℹ Testing VISCtemplates
✔ | F W  S  OK | Context
✔ |          2 | use_visc_report                                                        
✔ |          6 | knit generic report pdf [7.2s]                                         
✔ |          6 | knit generic report docx [3.9s]                                        
✔ |          6 | knit empty report pdf [4.9s]                                           
✔ |          6 | knit empty report docx [10.5s]                                         
✔ |          6 | knit bama report pdf [9.1s]                                            
✔ |          6 | knit bama report docx [4.5s]                                           
✔ |          6 | knit nab report pdf [10.8s]                                            
✔ |          6 | knit nab report docx [5.6s]                                            
✔ |         10 | visc_load_pdata [7.7s]                                                 

```