### PR TITLE
Update NEWS for 1.3.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# VISCtemplates 1.2.0
+
+* Update Fred Hutch logo in Word and PDF templates
+* Fix continuous integration issues (GitHub actions)
+* New GitHub action to auto-generate empty report template in Word and PDF (for verifying format with PRs) and associated template fixes
+* Fix double section numbering issue in Word doc template
+* Add visc_load_pdata and DataPackageR to Rmd template code
 
 # VISCtemplates 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,44 @@
+# VISCtemplates (development version)
+
+Bug Fixes
+* Fix major bug that broke PDF knitting on pandoc >= 3.1.7 (#159)
+* Fix bug that occurred when a report subdirectory did not already exist, and add unit test (#173)
+* Fix `insert_break()` to actually create a page break (#188)
+  + Update documentation to instruct users to use `\newpage` instead in new code
+
+Improvements to Report Templates
+* Update header logo for SCHARP/Fred Hutch branding compliance (#195)
+* Update templates and documentation for using correct syntax for multiple citations (#191)
+* Add section number to References section in PDF output (#176)
+
+Testing and Continuous Integration
+* Create unit tests to test knit all report templates to PDF and Word (#168, #182, #186, #187, #192)
+  + Test locally via `devtools::test()`; files written to `testthat/_snaps`
+  + On pull requests, test reports are written to file snapshots on GitHub Actions
+* Add GitHub Actions runner to test statsrv compatibility by matching its R and pandoc versions (#172)
+* Add `interactive = FALSE` option to interactive functions to facilitate automated unit testing (#168)
+* Speed up GitHub Action that renders skeleton.Rmd (#166)
+  + But then remove it entirely once superseded by more thorough test knitting (#178)
+
+Documentation and UI Improvements
+* Fix bad URL in GitHub setup instructions (#185)
+* Add guidance for where to install data packages (#154)
+* Add friendly error message to visc_load_pdata() when data package is not installed (#152)
+
+Package Maintenance
+* Adjust filenames in R/ and tests/ to follow best practices (#175, #179)
+* Respect existing getOption('repos') instead of forcing CRAN installations (#163)
+* Adjust dependencies in DESCRIPTION (#164)
+
+Kellie
+* #189 - Kellie
+* #190 - Kellie
+* (#196 - Kellie, once merged)
+* #160 - Kellie
+* #153 - Kellie
+* #144 - Kellie
+* #143 - Kellie
+
 # VISCtemplates 1.2.0
 
 * Update Fred Hutch logo in Word and PDF templates


### PR DESCRIPTION
- added belated NEWS items for 1.2.0, copied from the current GitHub release
- added NEWS items for 1.3.0 (currently 'development version' in NEWS, but that will change during the release process)
- @kelliemac, can you maybe flesh out NEWS items for things in the `Kellie` section, and file them into the appropriate sections as needed?
- Feel free to tweak anything else in here as well! I tried to order the items in approximate order of importance for a typical end user who isn't one of the package developers, since that's mostly who the NEWS is for.
- We've been busy! Should we add a note to the CONTRIBUTING.md and/or any other PR guidelines that it would be nice for a NEWS update to come along with each PR, to keep us more current on what we've done?  And to try to remind each other/everyone to keep up to date on that with each PR? If we did that now, it would be more visible since it would be in the `main` branch also.