### PR TITLE
Update PT report naming practices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # VISCtemplates (development version)
 
+* Update PT report naming practices to the format VDCnnn_assay_PTreport_interim/final_(un)blinded.Rmd
+
 # VISCtemplates 1.3.0
 
 Bug Fixes

--- a/R/use_visc_report.R
+++ b/R/use_visc_report.R
@@ -119,7 +119,7 @@ use_bib <- function(study_name) {
 #'   report_type = "bama"
 #'   )
 #' }
-use_visc_report <- function(report_name = "PT-Report",
+use_visc_report <- function(report_name = "PTreport",
                             path = ".",
                             report_type = c("empty", "generic", "bama", "nab"),
                             interactive = TRUE) {
@@ -159,10 +159,10 @@ challenge_visc_report <- function(report_name, interactive = TRUE) {
   continue <- usethis::ui_yeah("
     Creating a new VISC PT Report called {report_name}.
     At VISC, we use a naming convention for PT reports:
-    'VDCnnn_assay_PT_Report_statusifapplicable'
-    where 'statusifapplicable' distinguishes blinded reports,
-    HIV status, or something that distinguishes a type/subset
-    of a report.
+    'VDCnnn_assay_PTreport_status_blindingifapplicable'
+    where 'status' should be either 'interim' or 'final'
+    and 'blindingifapplicable' should be either 'blinded'
+    or 'unblinded' (applicable to interim reports only).
     'VDC' is the PI name and 'nnn' is the study number.
     Would you like to continue?")
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Use a VISC Report:
 
 ``` r
 use_visc_report(
-  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
+  report_name = "VDCnnn_BAMA_PTreport_interim_blinded", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", "bama", or "nab"
 )

--- a/man/use_visc_report.Rd
+++ b/man/use_visc_report.Rd
@@ -5,7 +5,7 @@
 \title{Use a VISC Report Template}
 \usage{
 use_visc_report(
-  report_name = "PT-Report",
+  report_name = "PTreport",
   path = ".",
   report_type = c("empty", "generic", "bama", "nab"),
   interactive = TRUE

--- a/vignettes/using_pdf_and_word_template.Rmd
+++ b/vignettes/using_pdf_and_word_template.Rmd
@@ -21,7 +21,7 @@ To use a VISC report template, run:
 
 ```{r eval=FALSE}
 use_visc_report(
-  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
+  report_name = "VDCnnn_BAMA_PTreport_interim_blinded", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", "bama", or "nab"
 )
@@ -33,9 +33,9 @@ example above, this structure looks like:
 
 ```
 |- BAMA/
-|  +- VDCnnn_BAMA_PT_Report_statusifapplicable/              
-|     +- BAMA-PT-Report.Rmd             # VISC report template
-|     +- methods/                       # folder with "child" .Rmd documents
+|  +- VDCnnn_BAMA_PTreport_interim_blinded/              
+|     +- VDCnnn_BAMA_PTreport_interim_blinded.Rmd       # VISC report template
+|     +- methods/                                       # folder with "child" .Rmd documents
 |       +- biological-endpoints.Rmd
 |       +- lab-methods.Rmd
 |       +- statistical-methods.Rmd


### PR DESCRIPTION
## Description

Per discussion with Alicia and Bryan, updated PT report file naming format to VDCnnn_assay_PTreport_status_blindingifapplicable, for example:

- VDCnnn_BAMA_PTreport_interim_blinded.Rmd
- VDCnnn_BAMA_PTreport_interim_unblinded.Rmd
- VDCnnn_BAMA_PTreport_final.Rmd

## Related Issues

Related to https://github.com/FredHutch/VISCtemplates/issues/98

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [X] I have updated NEWS.md to describe the proposed changes
