### PR TITLE
Reconcile skeleton.Rmd files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # VISCtemplates (development version)
 
+* Reconcile differences between empty report template and other report templates (#204)
+
 # VISCtemplates 1.3.0
 
 Bug Fixes

--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -8,10 +8,12 @@ from:
    contact: true
  - name: FirstNameB LastNameB
 to:
- - name: FirstNameA LastNameA
+ - name: FirstNameC LastNameC
+ - name: FirstNameD LastNameD
 dropcc: false
 cc:
- - name: FirstNameA LastNameA
+ - name: FirstNameE LastNameE
+ - name: FirstNameF LastNameF
 includesummary: true
 summary: 
   A short summary about your report. 
@@ -26,6 +28,7 @@ output:
 ---
 
 <!---
+This section is required according to WI-0010.
 Program Name:
 Creation Date:
 Full name of author:
@@ -36,19 +39,27 @@ Location of input data:
 --->
 
 ```{r package-loading-and-options, include=FALSE}
+
+# packages installed from GitHub
 library(VISCtemplates)
 library(VISCfunctions)
 
 check_pandoc_version()
 
-packages_needed <- c("conflicted", "tidyverse", "knitr", "kableExtra")
-
+# packages installed from CRAN
+packages_needed <- c("conflicted", "tidyverse", "knitr", "kableExtra", "rprojroot", "remotes")
 install_load_cran_packages(packages_needed)
 
 # knitr options
-opts_chunk$set(cache = FALSE, message = TRUE, warning = TRUE, echo = FALSE, 
-               dev = c("png", "pdf"), dpi = 200, out.width = '100%', 
-               out.extra = '', fig.pos = "H")
+opts_chunk$set(cache = FALSE,
+               message = TRUE,
+               warning = TRUE,
+               echo = FALSE, 
+               dev = c("png", "pdf"),
+               dpi = 200,
+               out.width = "100%", 
+               out.extra = "",
+               fig.pos = "H")
 # fig.align argument is not supported in Word (align in template docx)
 if (knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex'){
   opts_chunk$set(fig.align = "center")
@@ -57,24 +68,12 @@ if (knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex'){
 # NA's will be blank in tables
 options(knitr.kable.NA = '')
 
-# Create a theme 
+# Create a ggplot theme for consistency of figures
 visc_theme <- theme_bw() + 
-  theme(
-    legend.position = "bottom", 
-    legend.margin = margin(unit = "cm"),
-    panel.grid.minor = element_blank()
-    )
-
+  theme(legend.position = "bottom", 
+        legend.margin = margin(unit = "cm"),
+        panel.grid.minor = element_blank())
 theme_set(visc_theme)
-
-# Set group colors for this example.
-# If you have group colors already in your project:
-# source(rprojroot::find_rstudio_root_file("docs", "group-colors.R"), local = TRUE)
-group_colors <- c(
-  `1` = "#D92321",
-  `2` = "#1749FF",
-  `4` = "#0AB7C9"
-)
 ```
 
 ```{r conflicted-preferences, message=FALSE}
@@ -90,6 +89,20 @@ output_type <- get_output_type()
 kable_warnings <- set_kable_warnings(output_type)
 pandoc_markup <- set_pandoc_markup(output_type)
 ```
+
+```{r read-data}
+
+# Read in your data in this chunk
+
+```
+
+```{r data-processing}
+
+# Do your data processing in this chunk
+
+```
+
+\newpage
 
 # Section Header
 
@@ -128,6 +141,12 @@ kable(
   ) %>% 
   kable_styling(font_size = 10, latex_options = "hold_position")
 ```
+
+\newpage
+
+# Acknowledgements
+
+Include your acknowledgements in this section.
 
 \newpage
 

--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -47,7 +47,7 @@ library(VISCfunctions)
 check_pandoc_version()
 
 # packages installed from CRAN
-packages_needed <- c("conflicted", "tidyverse", "knitr", "kableExtra", "rprojroot", "remotes")
+packages_needed <- c("conflicted", "dplyr", "knitr", "kableExtra", "rprojroot")
 install_load_cran_packages(packages_needed)
 
 # knitr options
@@ -135,7 +135,8 @@ kable(
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
 kable(
   my_session_info$packages_table, 
-  format = output_type, booktabs = TRUE, 
+  format = output_type,
+  booktabs = TRUE, 
   linesep = "", 
   caption = "Reproducibility software package version information"
   ) %>% 

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -8,19 +8,12 @@ from:
    contact: true
  - name: FirstNameB LastNameB
 to:
- - name: FirstNameA LastNameA
- - name: FirstNameB LastNameB
  - name: FirstNameC LastNameC
  - name: FirstNameD LastNameD
- - name: FirstNameE LastNameE
- - name: FirstNameF LastNameF
 dropcc: false
 cc:
- - name: FirstNameA LastNameA
- - name: FirstNameB LastNameB
- - name: FirstNameC LastNameC
- - name: FirstNameD LastNameD
  - name: FirstNameE LastNameE
+ - name: FirstNameF LastNameF
 includesummary: true
 summary: 
   A short summary about your report. 
@@ -62,9 +55,15 @@ my_data_package_lib <- "/Volumes/kmacphee/RLib/" # UPDATE WITH YOUR DATA PACKAGE
 .libPaths(c(.libPaths(), my_data_package_lib))
 
 # knitr options
-opts_chunk$set(cache = FALSE, message = TRUE, warning = TRUE, echo = FALSE, 
-               dev = c("png", "pdf"), dpi = 200, out.width = "100%", 
-               out.extra = "", fig.pos = "H")
+opts_chunk$set(cache = FALSE,
+               message = TRUE,
+               warning = TRUE,
+               echo = FALSE, 
+               dev = c("png", "pdf"),
+               dpi = 200,
+               out.width = "100%", 
+               out.extra = "",
+               fig.pos = "H")
 # fig.align argument is not supported in Word (align in template docx)
 if (knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex'){
   opts_chunk$set(fig.align = "center")
@@ -73,14 +72,11 @@ if (knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex'){
 # NA's will be blank in tables
 options(knitr.kable.NA = '')
 
-# Create a theme 
+# Create a ggplot theme for consistency of figures
 visc_theme <- theme_bw() + 
-  theme(
-    legend.position = "bottom", 
-    legend.margin = margin(unit = "cm"),
-    panel.grid.minor = element_blank()
-    )
-
+  theme(legend.position = "bottom", 
+        legend.margin = margin(unit = "cm"),
+        panel.grid.minor = element_blank())
 theme_set(visc_theme)
 
 # Set group colors for this example.

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -382,7 +382,8 @@ kable(
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
 kable(
   my_session_info$packages_table, 
-  format = output_type, booktabs = TRUE, 
+  format = output_type,
+  booktabs = TRUE, 
   linesep = "", 
   caption = "Reproducibility software package version information"
   ) %>% 


### PR DESCRIPTION
## Description

I noticed that there were some inconsistencies between the visc_empty and visc_report skeleton.Rmd files. I attempted to resolve those and also to keep the visc_empty skeleton.Rmd as minimal as possible.

Question for reviewers:

1. Does the visc_empty skeleton.Rmd contain all of the basic elements?
2. Is there anything in the visc_empty skeleton.Rmd that could be simplified further?
3. Are the changes to visc_report skeleton.Rmd acceptable?

## Related Issues

Related to https://github.com/FredHutch/VISCtemplates/issues/203

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
