### PR TITLE
Re-flip header logos

### DIFF
--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -238,12 +238,12 @@ $endif$
 % set header and footer
 \renewcommand{\headrulewidth}{0.8pt}
 \renewcommand{\footrulewidth}{0.8pt}
-\fancyhead[L]{\includegraphics[height=0.8cm]{$logo_path_scharp$}}
+\fancyhead[L]{\includegraphics[height=0.8cm]{$logo_path_fh$}}
 $if(dropVISClogo)$
 $else$
 \fancyhead[C]{\includegraphics[height=0.8cm]{$logo_path_visc$}}
 $endif$
-\fancyhead[R]{\includegraphics[height=0.8cm]{$logo_path_fh$}}
+\fancyhead[R]{\includegraphics[height=0.8cm]{$logo_path_scharp$}}
 \fancyfoot[C]{Page \thepage{}~of~\pageref{LastPage}}
 \setlength{\headheight}{27pt}
 


### PR DESCRIPTION
Looks like the flipping of the Fred Hutch and SCHARP logos in #195 got undone by #196, which made it into the 1.3.0 release. This PR fixes that, so that we have the intended orientation recently approved over Slack, with Fred Hutch on the left and SCHARP on the right.

We may actually want to do a 1.3.1 patch release for this so that people are using the approved logo orientation. I can go ahead and do that if we want @kelliemac.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
