### PR TITLE
Remove dependency on full tidyverse

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,8 +63,8 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", ref = "untidy", dependencies = TRUE)'
-          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", ref = "untidy", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr"))'
           R -q -e 'utils::install.packages("rcmdcheck")'
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,7 +63,7 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", ref = "untidy", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", ref = "untidy", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr"))'
           R -q -e 'utils::install.packages("rcmdcheck")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,8 +65,8 @@ jobs:
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
+          R -q -e 'utils::install.packages(c("ggplot2", "dplyr"))'
           R -q -e 'utils::install.packages("rcmdcheck")'
-          R -q -e 'utils::install.packages("tidyverse")'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         if: ${{ matrix.config.r != '4.0.4' }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,7 +63,7 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", ref = "untidy", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", ref = "untidy", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr"))'
           R -q -e 'utils::install.packages("rcmdcheck")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,8 +63,8 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
-          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", ref = "untidy", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", ref = "untidy", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr"))'
           R -q -e 'utils::install.packages("rcmdcheck")'
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,11 +45,12 @@ RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 Suggests: 
     conflicted,
+    dplyr,
+    ggplot2,
     kableExtra,
     knitr,
     remotes,
     testthat (>= 3.0.0),
-    tidyverse,
     withr
 Remotes:
     FredHutch/VISCfunctions

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # VISCtemplates (development version)
 
 * Reconcile differences between empty report template and other report templates (#204)
+* Remove dependency on the full tidyverse, per best practices (#213)
 
 # VISCtemplates 1.3.1
 

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -47,7 +47,7 @@ library(VISCfunctions)
 check_pandoc_version()
 
 # packages installed from CRAN
-packages_needed <- c("conflicted", "tidyverse", "knitr", "kableExtra", "rprojroot", "remotes")
+packages_needed <- c("conflicted", "ggplot2", "dplyr", "knitr", "kableExtra", "rprojroot", "remotes")
 install_load_cran_packages(packages_needed)
 
 # where to install and look for packages (e.g., data packages) installed on SCHARP server


### PR DESCRIPTION
Removing `tidyverse` from dependencies per best practices.

From: https://cran.r-project.org/web/packages/tidyverse/vignettes/paper.html

> The tidyverse package is designed with an eye for teaching: install.packages("tidyverse") gets you a “batteries-included” set of 87 packages (at time of writing). This large set of dependencies means that it is not appropriate to use the tidyverse package within another package; instead, we recommend that package authors import only the specific packages that they use.