### PR TITLE
Hotfix: change \newpage to \clearpage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ Bug Fixes
 * Fix bug with latex packages (specifically etex's \reserveinserts command) that broke PDF knitting (#160)
 * Fix bug that occurred when a report subdirectory did not already exist, and add unit test (#173)
 * Fix `insert_break()` to actually create a page break (#188)
-  + Update documentation to instruct users to use `\newpage` instead in new code
+  + Update documentation to instruct users to use latex command instead in new code
 
 Improvements to Report Templates
 * Update header logo for SCHARP/Fred Hutch branding compliance (#195)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # VISCtemplates (development version)
 
 Bug Fix
-* Fix issue with insert_break() not inserting page breaks at times by replacing \newpage with \clearpage (#216)
+* Fix issue with insert_break() not inserting page breaks at times (#216)
 
 Other improvements
 * Reconcile differences between empty report template and other report templates (#204)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# VISCtemplates 1.3.2
+
+Bug Fix
+* Fix issue with insert_break() not inserting page breaks at times by replacing \newpage with \clearpage (#216)
+
 # VISCtemplates 1.3.1
 
 Bug Fix

--- a/R/report_functions.R
+++ b/R/report_functions.R
@@ -81,16 +81,17 @@ insert_ref <- function(ref, section_name = NA) {
 }
 
 
-#' Insert a page break (deprecated)
+#' Insert a page break
 #'
-#' Do not use in new code. Use latex command
-#' \code{\\clearpage} in your Rmd instead. This function is retained to not
-#' break old Rmd files created from previous templates.
+#' Use this function in your Rmd document to create a page break across PDF or
+#' Word output types
 #'
-#' @return Inserts a page break (deprecated)
+#' @return Inserts a page break
 #' @export
 insert_break <- function() {
-  '\\clearpage'
+  ifelse(knitr::opts_knit$get('rmarkdown.pandoc.to') == 'latex',
+         '\\clearpage',
+         '\\newpage')
 }
 
 #' Insert references section header

--- a/R/report_functions.R
+++ b/R/report_functions.R
@@ -84,13 +84,13 @@ insert_ref <- function(ref, section_name = NA) {
 #' Insert a page break (deprecated)
 #'
 #' Do not use in new code. Use latex command
-#' \code{\\newpage} in your Rmd instead. This function is retained to not
+#' \code{\\clearpage} in your Rmd instead. This function is retained to not
 #' break old Rmd files created from previous templates.
 #'
 #' @return Inserts a page break (deprecated)
 #' @export
 insert_break <- function() {
-  '\\newpage'
+  '\\clearpage'
 }
 
 #' Insert references section header

--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -99,7 +99,7 @@ Add some text here
 
 Add some text here
 
-\newpage
+\clearpage
 
 # Reproducibility Software Information
 
@@ -129,6 +129,6 @@ kable(
   kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
-\newpage
+\clearpage
 
 `r insert_references_section_header()`

--- a/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_empty/skeleton/skeleton.Rmd
@@ -112,7 +112,7 @@ Add some text here
 
 Add some text here
 
-\clearpage
+`r insert_break()`
 
 # Reproducibility Software Information
 
@@ -143,7 +143,7 @@ kable(
   kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
-\clearpage
+`r insert_break()`
 
 # Acknowledgements
 

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -129,7 +129,7 @@ ICS_adata <- exampleData_ICS %>%
   filter(Population == "IFNg" & Group != 3)
 ```
 
-\newpage
+\clearpage
 
 # Summary of Main Results
 
@@ -285,7 +285,7 @@ Consider breaking up the results section by objective or by statistical endpoint
 Make sure to include p-values and references to relevant tables and figures. 
 See Figure `r insert_ref("fig:example-plot")` and Table `r insert_ref("tab:example-tab")`. 
 
-\newpage
+\clearpage
 
 # Figures and Tables
 
@@ -331,7 +331,7 @@ ICS_adata %>%
   )
 ```
 
-\newpage
+\clearpage
 
 ```{r example-tab, results="asis", warning=kable_warnings}
 
@@ -365,7 +365,7 @@ magnitude_tab %>%
   footnote("SD: standard deviation.", threeparttable = TRUE)
 ```
 
-\newpage
+\clearpage
 
 ```{r Software-Session-Information, results="asis", message=FALSE, warning=kable_warnings}
 # load in rmarkdown to capture verison number
@@ -393,7 +393,7 @@ kable(
   kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
-\newpage
+\clearpage
 
 # Acknowledgements
 

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -125,7 +125,7 @@ ICS_adata <- exampleData_ICS %>%
   filter(Population == "IFNg" & Group != 3)
 ```
 
-\clearpage
+`r insert_break()`
 
 # Summary of Main Results
 
@@ -281,7 +281,7 @@ Consider breaking up the results section by objective or by statistical endpoint
 Make sure to include p-values and references to relevant tables and figures. 
 See Figure `r insert_ref("fig:example-plot")` and Table `r insert_ref("tab:example-tab")`. 
 
-\clearpage
+`r insert_break()`
 
 # Figures and Tables
 
@@ -327,7 +327,7 @@ ICS_adata %>%
   )
 ```
 
-\clearpage
+`r insert_break()`
 
 ```{r example-tab, results="asis", warning=kable_warnings}
 
@@ -361,7 +361,7 @@ magnitude_tab %>%
   footnote("SD: standard deviation.", threeparttable = TRUE)
 ```
 
-\clearpage
+`r insert_break()`
 
 ```{r Software-Session-Information, results="asis", message=FALSE, warning=kable_warnings}
 # load in rmarkdown to capture verison number
@@ -390,7 +390,7 @@ kable(
   kable_styling(font_size = 10, latex_options = "hold_position")
 ```
 
-\clearpage
+`r insert_break()`
 
 # Acknowledgements
 

--- a/man/insert_break.Rd
+++ b/man/insert_break.Rd
@@ -11,6 +11,6 @@ Inserts a page break (deprecated)
 }
 \description{
 Do not use in new code. Use latex command
-\code{\\newpage} in your Rmd instead. This function is retained to not
+\code{\\clearpage} in your Rmd instead. This function is retained to not
 break old Rmd files created from previous templates.
 }

--- a/man/insert_break.Rd
+++ b/man/insert_break.Rd
@@ -2,15 +2,14 @@
 % Please edit documentation in R/report_functions.R
 \name{insert_break}
 \alias{insert_break}
-\title{Insert a page break (deprecated)}
+\title{Insert a page break}
 \usage{
 insert_break()
 }
 \value{
-Inserts a page break (deprecated)
+Inserts a page break
 }
 \description{
-Do not use in new code. Use latex command
-\code{\\clearpage} in your Rmd instead. This function is retained to not
-break old Rmd files created from previous templates.
+Use this function in your Rmd document to create a page break across PDF or
+Word output types
 }

--- a/vignettes/using_pdf_and_word_template.Rmd
+++ b/vignettes/using_pdf_and_word_template.Rmd
@@ -67,7 +67,7 @@ There are some new functions and coding conventions that help with knitting the 
 
 ### Page breaks
 
-* For page breaks use `\newpage`.
+* For page breaks use `\clearpage`.
     
 ### Referencing
 `

--- a/vignettes/using_pdf_and_word_template.Rmd
+++ b/vignettes/using_pdf_and_word_template.Rmd
@@ -67,7 +67,7 @@ There are some new functions and coding conventions that help with knitting the 
 
 ### Page breaks
 
-* For page breaks use `\clearpage`.
+* For page breaks use `insert_break()` function.
     
 ### Referencing
 `


### PR DESCRIPTION
## Description

Yung-Wen noticed an issues with two figures being crammed onto the same page and running off the page when using the latest VISCtemplates to render a previous PT report. I was able to reproduce the issue and trace it to a limitation of the \newpage command that is now being used by insert_break(). Changing \newpage to \clearpage resolves the issue.

Helpful explanation of the differences between \newpage and \clearpage: https://tex.stackexchange.com/questions/497746/comparison-between-newpage-clearpage-and-pagebreak-etc

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
