### PR TITLE
README.md instead of README.Rmd

### DIFF
--- a/R/use_visc_report.R
+++ b/R/use_visc_report.R
@@ -16,6 +16,21 @@ use_visc_readme <- function(study_name, save_as = "README.Rmd") {
     data = list(study_name = study_name),
     package = "VISCtemplates"
   )
+  # knit the md from the Rmd on request of SRA team
+  rmarkdown::render(
+    usethis::proj_path('README.Rmd'),
+    quiet = TRUE
+  )
+  # remove Rmd at request of SRA team; they just manually edit the *.md
+  # so the Rmd file merely clutters their working directory
+  unlink(
+    usethis::proj_path(
+      paste0(
+        'README',
+        c('.Rmd', '.html')
+      )
+    )
+  )
 }
 
 #' Create a VISC docs directory with template files


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

During `create_visc_project()`, build README.md from the Rmd template in VISCtemplates, then immediately discard the Rmd and html files.  SRAs just manually edit the md file in their workflow, so the Rmd file represents clutter in their working directory.

## Related Issues

Addresses #214.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
   - Will update NEWS once SRAs confirm this is what they want
