### PR TITLE
latex template fix to allow flextable to render tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 Bug fixes
 * Provide default CRAN mirror if missing in install_load_cran_packages(), e.g., in a child R session during knitting. Fixes 'trying to use CRAN without setting a mirror' error (#218)
+* Update template.tex so that flextable package can be used to create tables in PDF documents (#226)
 
 Other improvements
 * create_visc_project() now discards README.Rmd after knitting template to README.md (#223)

--- a/inst/rmarkdown/templates/visc_report/resources/template.tex
+++ b/inst/rmarkdown/templates/visc_report/resources/template.tex
@@ -20,6 +20,11 @@
 \usepackage{threeparttable} % provides a scheme for tables that have a structured (foot)note section, after the caption
 \usepackage{threeparttablex} % provides the functionality of the threeparttable package to tables created using the longtable package
 
+% needed for flextable to work
+\usepackage{hhline}
+\newlength\Oldarrayrulewidth
+\newlength\Oldtabcolsep
+
 % being able to set emphasis for entire table row
 \newcommand\setrow[1]{\gdef\rowmac{#1}#1\ignorespaces}
 \newcommand\clearrow{\global\let\rowmac\relax}


### PR DESCRIPTION
## Description

Currently, attempting to use `flextable` for PDF output results in an error due to a command missing in the `template.tex file`. This fix resolves that issue, and `flextable` can now be used to generate tables in both Word and PDF report documents.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
