### PR TITLE
Auto-calculate unit test coverage on PRs and view results on Codecov

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,6 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: '4.0.4', pandoc-version: '2.11.4'}
 
     env:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,61 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: test-coverage.yaml
+
+permissions: read-all
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, develop]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, develop]
 
 name: test-coverage.yaml
 
@@ -18,6 +18,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-tinytex@v2
+
+      - name: Preinstall required latex packages
+        run: >
+          tlmgr install
+          lastpage morefloats parskip pdflscape textpos multirow lipsum
+          fancyhdr colortbl soul setspace relsize makecell threeparttable
+          threeparttablex environ trimspaces
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/README.Rmd
+++ b/README.Rmd
@@ -81,7 +81,7 @@ Use a VISC Report:
 
 ```{r eval=FALSE}
 use_visc_report(
-  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
+  report_name = "VDCnnn_BAMA_PTreport_interim_blinded", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", "bama", or "nab"
 )

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,6 +13,11 @@ knitr::opts_chunk$set(
 )
 ```
 
+<!-- badges: start -->
+[![R-CMD-check](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/FredHutch/VISCtemplates/graph/badge.svg)](https://app.codecov.io/gh/FredHutch/VISCtemplates)
+<!-- badges: end -->
+
 # VISCtemplates
 
 The goal of VISCtemplates is to: 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Use a VISC Report:
 
 ``` r
 use_visc_report(
-  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
+  report_name = "VDCnnn_BAMA_PTreport_interim_blinded", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", "bama", or "nab"
 )

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+<!-- badges: start -->
+
+[![R-CMD-check](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml)
+[![Codecov test
+coverage](https://codecov.io/gh/FredHutch/VISCtemplates/graph/badge.svg)](https://app.codecov.io/gh/FredHutch/VISCtemplates)
+<!-- badges: end -->
 
 # VISCtemplates
 
@@ -66,7 +72,7 @@ Use a VISC Report:
 
 ``` r
 use_visc_report(
-  report_name = "VDCnnn_BAMA_PTreport_interim_blinded", # the name of the report file
+  report_name = "VDCnnn_BAMA_PT_Report_statusifapplicable", # the name of the report file
   path = "BAMA", # the path within the active directory, usually the name of the assay
   report_type = "bama" # "empty", "generic", "bama", or "nab"
 )


### PR DESCRIPTION
- Worked with FredHutch scicomp to get Codecov permissions & secrets working for VISCtemplates
- Added GitHub Action to calculate unit test coverage on pushes and PRs
- Removed oldrel-1 from R CMD check matrix.config, since already testing back to R 4.0.4
- Added R CMD check and test coverage badges to README
- Rebuilt README.md from README.Rmd
- We should start to see the full functionality and benefits once this gets merged into develop / main
  - See [here](https://app.codecov.io/gh/FredHutch/VISCtemplates/tree/codecov_token_test) for coverage report example