### PR TITLE
Add explicit reference to the version of data package being installed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,8 @@ Other improvements
 * Update PT report naming practices to the format VDCnnn_assay_PTreport_interim/final_(un)blinded.Rmd (#202)
 * Add auxiliary files to template .gitignore (.aux, .toc, .lof, .lot, .out, cache files, and .smbdelete files) (#230)
 * Update names in template acknowledgements section (#234)
-* Gitignore html files in data-raw via use_visc_gitignore() (#254) 
+* Gitignore html files in data-raw via use_visc_gitignore() (#254)
+* Add explicit reference to the version of the data package being installed, and note about changing if needed (#257)
 
 # VISCtemplates 1.3.2
 

--- a/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/visc_report/skeleton/skeleton.Rmd
@@ -113,6 +113,7 @@ if (.Platform$OS.type == 'unix') {
 }
 
 remotes::install_git(file.path('cavd', 'Studies', 'cvdNNN', 'pdata', 'VDCNNN.git'),
+                     ref = 'main', # may need to change this to a different branch/tag/SHA to reproduce a specific analysis - see reproducibility tables in previous reports if appropriate
                      git = 'external', 
                      lib = my_data_package_lib)
 ```


### PR DESCRIPTION
## Description

add ref = "main" for data package installation and a comment about possibly needing to change this to reproduce an analysis from a particular point in time

## Related Issues

related to https://github.com/FredHutch/VISCtemplates/issues/240

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
