### PR TITLE
On statsrv CI Runner, specify install of most recent version of R package htmlTable that can install on R 4.0.4.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,6 +61,7 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
           R -q -e 'utils::install.packages("remotes")'
+          R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,8 @@ Other improvements
 * Update PT report naming practices to the format VDCnnn_assay_PTreport_interim/final_(un)blinded.Rmd (#202)
 * Add auxiliary files to template .gitignore (.aux, .toc, .lof, .lot, .out, cache files, and .smbdelete files) (#230)
 * Update names in template acknowledgements section (#234)
-* Gitignore html files in data-raw via use_visc_gitignore() (#254) 
+* Gitignore html files in data-raw via use_visc_gitignore() (#254)
+* Fix finicky installation of R package 'htmlTable' on statsrv CI runner (#261)
 
 # VISCtemplates 1.3.2
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

On statsrv CI Runner, specify install of most recent version of R package `htmlTable` that can install on R 4.0.4.

## Related Issues

Fixes broken R 4.0.4 CI noticed in #259

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
