### PR TITLE
install apt system dependencies on CI runners

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,7 +57,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install apt dependencies for all runners
+      - name: Install apt dependencies for all Linux runners
+        if: ${{ contains( matrix.config.os, 'ubuntu') }}
         run: |
           sudo apt install -y libgit2-dev
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,6 +57,10 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Install apt dependencies for all runners
+        run: |
+          sudo apt install -y libgit2-dev
+
       - name: Install statsrv packages
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,6 +62,7 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
+          sudo apt install -y libjpeg-dev
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
-          sudo apt install -y libjpeg-dev
+          sudo apt install -y libjpeg-dev libcurl4-openssl-dev
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ Other improvements
 * Update names in template acknowledgements section (#234)
 * Gitignore html files in data-raw via use_visc_gitignore() (#254)
 * Add explicit reference to the version of the data package being installed, and note about changing if needed (#257)
-* Fix finicky installation of R package 'htmlTable' on statsrv CI runner (#261)
+* Update installation of system dependencies and R packages on CI runners (#261, #265)
 
 # VISCtemplates 1.3.2
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Maintenance of GitHub Actions R CMD check workflow

All Linux runners:
- Install `libgit2-dev` to enable installation of indirect dependency R package `git2r`

Statsrv runner:
- Install `libjpeg-dev` to enable installation of indirect dependency R package `jpeg`
- Install `libcurl4-openssl-dev` to enable installation of indirect dependency R package `curl`

## Related Issues

Should fix CI issues noticed in https://github.com/FredHutch/VISCtemplates/pull/233.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
