### PR TITLE
fix formatting issue in assay level readme template, leftover from me…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Bug fixes
 * Fix error when running skeleton.Rmd file interactively (#249)
 * Include pdata object name and data package name in visc_load_pdata() error message (#252)
 * Add ggplot2 loading to visc_empty PT report skeleton to avoid rendering error (#256)
+* Fix formatting issue in assay folder README template (#266)
 
 Other improvements
 * create_visc_project() now discards README.Rmd after knitting template to README.md (#223)

--- a/inst/templates/README_assay_folder.md
+++ b/inst/templates/README_assay_folder.md
@@ -13,18 +13,16 @@
        - Find the report among the edits and click "View"
        - The hash is url: https://github.com/fredhutch/.../blob/hash/... -->
 
-| **Report Version** | **Date Sent to VDC**| **Unblinded** | **Data Spec. and Link**| **Commit Tag/Hash and Link** |
-|-------------|---------------------|---------------|---------------|-----------------|
-| **Report Version** | **Date sent to VDC** | **Unblinded** |  **Report Commit Tag/Hash and Link**    | **Pdata location** | **Pdata Commit**| 
+| **Report Version** | **Date Sent to VDC**| **Unblinded** | **Report Commit Tag/Hash and Link** | **Pdata location** | **Pdata Commit**| 
 |-----------|----------------------|-------------------|-------------|-------------------|---------------|
 |1.0 | [Date] | [Yes/No] | [tag/hash](https://github.com/fredhutch/...) | [location]  |  [hash]  | 
 
 For additional data, supplement table (long-format by report version if multiple data)
 
-| *Report Version* | *Data description* | *Data location* | *Data date*| 
+| *Report Version* | *Data Description* | *Data Location* | *Data Date*| 
 |-----------|----------------------|-------------------|------------------|
 |  1.0| [description]| [path]|  [Date]|   
-|  1.0| [description]| [path]|  [Date]|   
+|  2.0| [description]| [path]|  [Date]|   
 
 
 


### PR DESCRIPTION
## Description

this fixes a formatting issue I just noticed in the assay level readme template, which appears to be leftover from an attempt to resolve a merge conflict

## Related Issues / PRs

follow-up to https://github.com/FredHutch/VISCtemplates/pull/233

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
