### PR TITLE
tweak dependencies installs for CI statsrv runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,7 +67,7 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
-          sudo apt install -y libjpeg-dev libcurl4-openssl-dev libfontconfig1-dev
+          sudo apt install -y libjpeg-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libpng-dev libtiff5-dev
           R -q -e 'remotes::install_version("scales", "1.3.0")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,6 +68,7 @@ jobs:
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
           sudo apt install -y libjpeg-dev libcurl4-openssl-dev libfontconfig1-dev
+          R -q -e 'remotes::install_version("scales", "1.3.0")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ Other improvements
 and minimally structured README.md files are created at the report folder level at the same time (#233)
 * Reorganized inst/ folder within package for clarity (#233)
 * Add explicit reference to the version of the data package being installed, and note about changing if needed (#257)
-* Update installation of system dependencies and R packages on CI runners (#261, #265, #273)
+* Update installation of system dependencies and R packages on CI runners (#261, #265, #273, #278)
 * Update and clarify CONTRIBUTING.md (#269)
 
 # VISCtemplates 1.3.2


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

CI tweaks for dependencies on increasingly brittle statsrv runner

- force install of old version of `scales` R package (new version requires R 4.1)
- install apt system requirements for `ragg` R package so it can install from source

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
