### PR TITLE
install all pak-resolved apt dependencies on statsrv runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,17 +57,12 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install apt dependencies for all Linux runners
-        if: ${{ contains( matrix.config.os, 'ubuntu') }}
-        run: |
-          sudo apt install -y libgit2-dev
-
       - name: Install statsrv packages
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
-          sudo apt install -y libjpeg-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libpng-dev libtiff5-dev libharfbuzz-dev libfribidi-dev
+          sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev
           R -q -e 'remotes::install_version("scales", "1.3.0")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,7 +67,7 @@ jobs:
         run: |
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
-          sudo apt install -y libjpeg-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libpng-dev libtiff5-dev
+          sudo apt install -y libjpeg-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libpng-dev libtiff5-dev libharfbuzz-dev libfribidi-dev
           R -q -e 'remotes::install_version("scales", "1.3.0")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ Other improvements
 and minimally structured README.md files are created at the report folder level at the same time (#233)
 * Reorganized inst/ folder within package for clarity (#233)
 * Add explicit reference to the version of the data package being installed, and note about changing if needed (#257)
-* Update installation of system dependencies and R packages on CI runners (#261, #265, #273, #278)
+* Update installation of system dependencies and R packages on CI runners (#261, #265, #273, #278, #280)
 * Update and clarify CONTRIBUTING.md (#269)
 * Better default colors and shapes for reports (#268)
 


### PR DESCRIPTION
I noticed that on e.g. the r-release runner pak resolves all the apt system requirements and installs them in this line in the CI log:

```
  ℹ Executing `sudo sh -c apt-get -y install pandoc libx11-dev git libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev`
```

I copied this list to the statsrv runner install script to hopefully pre-empt future issues with missing system dependencies turning up on the statsrv runner when R packages get installed from source.

The list may need to be occasionally updated if we (or packages) add dependencies.