### PR TITLE
update NEWS item that slipped through the cracks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 Improvements for users
 * Add new helper functions `networks_path()` and `trials_path()` (#271)
+* Added ADCC template (#109)
 * Improvements to Word document formatting (#212, #281)
 * Better default colors and shapes for reports, in line with current report practices (#268)
 * Added to default gitignore: `.aux`, `.toc`, `.lof`, `.lot`, `.out`, `.smbdelete`, and cache files (#230); `.html` files in `data-raw/` (#255)


### PR DESCRIPTION
https://github.com/FredHutch/VISCtemplates/pull/109 had gotten merged without a NEWS update, but was in fact a new feature in the 2.0.0 release.

It's too late to add this NEWS to the released version of `main`, but we can update it here in `develop` so that it's in there going forward, and I can manually add it to the NEWS in the GitHub release for 2.0.0.