### PR TITLE
hardcode main branch into codecov URLs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,6 +61,7 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
           R -q -e 'utils::install.packages("remotes")'
+          Sys.setenv(R_REMOTES_UPGRADE = "never")
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
           sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev
           R -q -e 'remotes::install_version("scales", "1.3.0")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,6 +65,7 @@ jobs:
           sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev
           R -q -e 'remotes::install_version("scales", "1.3.0")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
+          R -q -e 'remotes::install_version("svglite", "2.1.3")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr", "flextable"))'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,12 +62,12 @@ jobs:
         run: |
           sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev
           R -q -e 'utils::install.packages("remotes")'
-          R -q -e 'remotes::install_version("htmlTable", "2.4.1", upgrade = "never")'
-          R -q -e 'remotes::install_version("scales", "1.3.0", upgrade = "never")'
-          R -q -e 'remotes::install_version("Hmisc", "4.5-0", upgrade = "never")'
-          R -q -e 'remotes::install_version("svglite", "2.1.3", upgrade = "never")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE, upgrade = "never")'
-          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE, upgrade = "never")'
+          R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
+          R -q -e 'remotes::install_version("scales", "1.3.0")'
+          R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
+          R -q -e 'remotes::install_version("svglite", "2.1.3")'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
+          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr", "flextable"))'
           R -q -e 'utils::install.packages("rcmdcheck")'
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -60,15 +60,14 @@ jobs:
       - name: Install statsrv packages
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
-          R -q -e 'utils::install.packages("remotes")'
-          Sys.setenv(R_REMOTES_UPGRADE = "never")
-          R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
           sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev
-          R -q -e 'remotes::install_version("scales", "1.3.0")'
-          R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_version("svglite", "2.1.3")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
-          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
+          R -q -e 'utils::install.packages("remotes")'
+          R -q -e 'remotes::install_version("htmlTable", "2.4.1", upgrade = "never")'
+          R -q -e 'remotes::install_version("scales", "1.3.0", upgrade = "never")'
+          R -q -e 'remotes::install_version("Hmisc", "4.5-0", upgrade = "never")'
+          R -q -e 'remotes::install_version("svglite", "2.1.3", upgrade = "never")'
+          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE, upgrade = "never")'
+          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE, upgrade = "never")'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr", "flextable"))'
           R -q -e 'utils::install.packages("rcmdcheck")'
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # VISCtemplates (development version)
 
+Improvements for package contributors and maintainers
+* Fix Codecov badge and URL (#287)
+* CI maintenance (#287)
+
 # VISCtemplates 2.0.0
 
 Improvements for users

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/FredHutch/VISCtemplates/graph/badge.svg)](https://app.codecov.io/gh/FredHutch/VISCtemplates)
+[![Codecov test coverage](https://codecov.io/gh/FredHutch/VISCtemplates/branch/main/graph/badge.svg)](https://app.codecov.io/gh/FredHutch/VISCtemplates/tree/main)
 <!-- badges: end -->
 
 # VISCtemplates

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![R-CMD-check](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/FredHutch/VISCtemplates/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/FredHutch/VISCtemplates/graph/badge.svg)](https://app.codecov.io/gh/FredHutch/VISCtemplates)
+coverage](https://codecov.io/gh/FredHutch/VISCtemplates/branch/main/graph/badge.svg)](https://app.codecov.io/gh/FredHutch/VISCtemplates/tree/main)
 <!-- badges: end -->
 
 # VISCtemplates


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

The codecov badge on https://github.com/FredHutch/VISCtemplates/blob/main/README.md is currently both unsightly and annoying, respectively, because it doesn't update and it links to a page that requires you to hand-specify the branch from a pull-down menu in order to see any useful info.

I had scicomp set the default branch to `main`, like the page suggests, but that didn't resolve either issue.

This PR hardcodes the badge URLs to show the badge for the `main` branch and to take straight to the `main` coverage info when they click the badge.

Always showing the `main` stats is probably fine, since that will reflect the latest released version and show up nicely on the VISCtemplates GitHub landing page.  The `develop` stats will still show up in the CI runs themselves, and we can still view detailed coverage for `develop` on the Codecov site by selecting `develop` on the branch drop-down menu.

Once merged to `main`, the landing page will look like this:

https://github.com/FredHutch/VISCtemplates/blob/codecov_urls/README.md

## Miscellaneous

Also contains a commit to install the most recent version of R pkg `svglite` that still supports R as old as the statsrv runner.  Did some other CI tweaking on statsrv runner, but ultimately just settled on the aforementioned and a tweak to make apt installs happen earlier.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
