### PR TITLE
fix visc_load_pdata() for when LazyLoad: true and add unit tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,6 +66,7 @@ jobs:
           R -q -e 'remotes::install_version("scales", "1.3.0")'
           R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
           R -q -e 'remotes::install_version("svglite", "2.1.3")'
+          R -q -e 'remotes::install_version("purrr", "1.0.4")'
           R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
           R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
           R -q -e 'utils::install.packages(c("ggplot2", "dplyr", "flextable"))'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
     bookdown,
     rmarkdown,
     rprojroot,
-    stringr,
     usethis,
     glue,
     utils,

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -19,7 +19,7 @@ create_visc_project <- function(path, interactive = TRUE){
   # get "VDCNNN" if it exists
   # this is a variable that is inserted into templates
   if (grepl("Analysis", repo_name, ignore.case = TRUE)) {
-    study_name <- gsub("Analysis", "", repo_name)
+    study_name <- sub("Analysis", "", repo_name)
   } else {
     study_name <- repo_name
   }

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -19,7 +19,7 @@ create_visc_project <- function(path, interactive = TRUE){
   # get "VDCNNN" if it exists
   # this is a variable that is inserted into templates
   if (grepl("Analysis", repo_name, ignore.case = TRUE)) {
-    study_name <- stringr::str_replace(repo_name, pattern = "Analysis", "")
+    study_name <- gsub("Analysis", "", repo_name)
   } else {
     study_name <- repo_name
   }

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -63,17 +63,20 @@ visc_load_pdata <- function(.data,
     }
     rda <- system.file(file.path('data', paste0(pdata_name, ".rda")),
                        package = pkg_name)
-    lz_rd <- system.file(file.path('data', 'Rdata'), package = pkg_name)
+    lz_rd <- system.file(
+      file.path('data', paste0('Rdata', c('.rdb', '.rds', '.rdx'))),
+      package = pkg_name
+    )
     lzd <- utils::packageDescription(pkg_name)$LazyData
+    lzd <- if (is.null(lzd)) FALSE else as.logical(lzd)
     if (nzchar(rda) && file.exists(rda)) {
       # single rda file for data object in data/
       load(system.file(file.path('data', paste0(pdata_name, ".rda")),
         package = pkg_name), envir = pdata_env)
-    } else if (nzchar(lz_rd) && file.exists(lz_rd) &&
-                 !is.null(lzd) && tolower(lzd) == 'true'){
-      # undocumented import method from legacy code. Ever needed? Untested.
-      lazyLoad(filebase = system.file(file.path('data', 'Rdata'),
-                 package = pkg_name), envir = pdata_env)
+    } else if (all(nzchar(lz_rd)) && all(file.exists(lz_rd)) && lzd){
+      # when LazyLoad: true in DESCRIPTION
+      # and therefore the installed package directory has no data/*.rda files
+      utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
     } else {
       stop(
         sprintf(

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -73,9 +73,8 @@ visc_load_pdata <- function(.data,
     }
   }
 
-
-  pdata <- get(pdata_name, envir = pdata_env)
   message("Loading ", pdata_name, " from ", proj_or_datapackage)
+  pdata <- get(pdata_name, envir = pdata_env)
 
   if(!is.null(criteria)){
     if(nchar(criteria) == 32){

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -50,7 +50,7 @@ visc_load_pdata <- function(.data,
 
   }
 
-  pdata_env <- new.env()
+  pdata_env <- new.env(parent = emptyenv())
   if(tolower(proj_or_datapackage) %in% c("proj", "repo")){
     # data package project / source folder method
     load(DataPackageR::project_data_path(paste0(pdata_name, ".rda")),

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -33,7 +33,7 @@ visc_load_pdata <- function(.data,
                             criteria = NULL){
 
   pdata_name <- deparse(substitute(.data))
-  pkg_name <- stringr::str_split(pdata_name, pattern = "_")[[1]][1]
+  pkg_name <- strsplit(pdata_name, "_")[[1]][1]
 
   # r/o picnic
   if (is.null(criteria)) {

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -61,23 +61,8 @@ visc_load_pdata <- function(.data,
     if (! pkg_name %in% rownames(utils::installed.packages())){
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
-    rda <- system.file(file.path('data', paste0(pdata_name, ".rda")),
-                       package = pkg_name)
-    lz_rd <- system.file(
-      file.path('data', paste0('Rdata', c('.rdb', '.rds', '.rdx'))),
-      package = pkg_name
-    )
-    lzd <- utils::packageDescription(pkg_name)$LazyData
-    lzd <- if (is.null(lzd)) FALSE else as.logical(lzd)
-    if (nzchar(rda) && file.exists(rda)) {
-      # single rda file for data object in data/
-      load(system.file(file.path('data', paste0(pdata_name, ".rda")),
-        package = pkg_name), envir = pdata_env)
-    } else if (all(nzchar(lz_rd)) && all(file.exists(lz_rd)) && lzd){
-      # when LazyLoad: true in DESCRIPTION
-      # and therefore the installed package directory has no data/*.rda files
-      utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
-    } else {
+    utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
+    if (! pdata_name %in% ls(pdata_env)){
       stop(
         sprintf(
           "Unable to find data object '%s' in package '%s'",

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -62,7 +62,7 @@ visc_load_pdata <- function(.data,
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
     utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
-    if (! pdata_name %in% ls(pdata_env)){
+    if (! exists(pdata_name, pdata_env)){
       stop(
         sprintf(
           "Unable to find data object '%s' in package '%s'",

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -89,7 +89,6 @@ test_that("visc_load_pdata works", {
     desc_path <- file.path(td, "Visc777", "DESCRIPTION")
     new_desc <- c(readLines(desc_path), 'LazyData: true')
     writeLines(new_desc, desc_path)
-    readLines(desc_path)
     # do install
     suppressMessages({
       pb_res <- DataPackageR::package_build(file.path(td, "Visc777"),

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -48,6 +48,11 @@ test_that("visc_load_pdata works", {
       pb_res <- DataPackageR::package_build(file.path(td, "Visc777"),
                                             install = TRUE, quiet = TRUE)
     })
+    # test RDA style package data installation
+    expect_equal(
+        'Visc777_cars.rda',
+        list.files(file.path(.libPaths()[1], 'Visc777', 'data'))
+    )
     # right hash
     expect_no_error(
       suppressMessages({
@@ -79,6 +84,42 @@ test_that("visc_load_pdata works", {
         )
       }),
       "Unable to find data object.*"
+    )
+    # Reinstall package with LazyData: true in DESCRIPTION field
+    desc_path <- file.path(td, "Visc777", "DESCRIPTION")
+    new_desc <- c(readLines(desc_path), 'LazyData: true')
+    writeLines(new_desc, desc_path)
+    readLines(desc_path)
+    # do install
+    suppressMessages({
+      pb_res <- DataPackageR::package_build(file.path(td, "Visc777"),
+                                            install = TRUE, quiet = TRUE)
+    })
+    # test LazyData style package data installation
+    expect_true(
+      setequal(
+        c('Rdata.rdb', 'Rdata.rds', 'Rdata.rdx'),
+        list.files(file.path(.libPaths()[1], 'Visc777', 'data'))
+      )
+    )
+    # right hash
+    expect_no_error(
+      suppressMessages({
+        pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
+                                            'datapackage',
+                                            '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+        )
+      })
+    )
+    # wrong hash
+    expect_error(
+      suppressMessages({
+        visc_load_pdata(Visc777_cars,
+                        'datapackage',
+                        'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
+        )
+      }),
+      "pdata_digest.*not equal to.*criteria.*expected"
     )
   })
 })

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -78,10 +78,12 @@ test_that("visc_load_pdata works", {
     )
     expect_error(
       suppressMessages({
-        visc_load_pdata(Visc777_cars,
-                        'datapackage',
-                        '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
-        )
+        suppressWarnings({
+          visc_load_pdata(Visc777_cars,
+                          'datapackage',
+                          '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+          )
+        })
       }),
       "Unable to find data object.*"
     )


### PR DESCRIPTION
## Description

@Sal4321 today provided a reprex in Slack of a datapackage where `visc_load_pdata()` didn't work but `data()` did.  Upon further inspection, the error was coming from a legacy code branch within `visc_load_pdata()` that was known and labeled to be under-documented and not covered by existing unit tests.

DPR2 uses LazyData: true by default in the DESCRIPTION file of a new datapackage.  When you install a datapackage with this, the file structure changes the _installed_ data directory such that the old visc_load_pdata() code couldn't find the data.  It wasn't noticed before because most of our datapackges don't use LazyData: true.

This PR fixes that code and adds unit tests.

## Related Issues

https://github.com/FredHutch/DPR2/issues/83

## Checklist

- [x] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
