### PR TITLE
more maintainable statsrv runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,28 +51,23 @@ jobs:
           fancyhdr colortbl soul setspace relsize makecell threeparttable
           threeparttablex environ trimspaces
 
+      - name: Setup recent R
       - uses: r-lib/actions/setup-r@v2
+        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install statsrv packages
+      - name: Setup R 4.0.4
+      - uses: r-lib/actions/setup-r@v2
         if: ${{ matrix.config.r == '4.0.4' }}
-        run: |
-          sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev make libcairo2-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libjpeg-dev libpng-dev libtiff-dev libicu-dev libfribidi-dev libharfbuzz-dev libxml2-dev libssh2-1-dev zlib1g-dev
-          R -q -e 'utils::install.packages("remotes")'
-          R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
-          R -q -e 'remotes::install_version("scales", "1.3.0")'
-          R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_version("svglite", "2.1.3")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
-          R -q -e 'remotes::install_github("FredHutch/VISCtemplates", dependencies = TRUE)'
-          R -q -e 'utils::install.packages(c("ggplot2", "dplyr", "flextable"))'
-          R -q -e 'utils::install.packages("rcmdcheck")'
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2022-07-01'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           extra-packages: any::rcmdcheck
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,6 +64,7 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
+          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-01'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,6 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
-          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2022-07-01'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
-          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-01'
+          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-19'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,6 @@ jobs:
         if: ${{ matrix.config.r == '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
-          use-public-rspm: true
           cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2022-07-01'
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,7 @@ jobs:
           threeparttablex environ trimspaces
 
       - name: Setup recent R
-      - uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@v2
         if: ${{ matrix.config.r != '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
@@ -60,7 +60,7 @@ jobs:
           use-public-rspm: true
 
       - name: Setup R 4.0.4
-      - uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@v2
         if: ${{ matrix.config.r == '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}


### PR DESCRIPTION
This PR makes it a lot easier to maintain the R 4.0.4 CI runner.
- uses a fixed-date CRAN mirror from April 2024
- no longer need to update the CI script when another dependency drops support for R 4.0.4
- can use automated pak apt dependency resolution again also
- in theory, no more special maintenance will be needed for this runner
- considerably decreases the CI runtime, too