### PR TITLE
Allow standard evaluation for visc_load_pdata() `.data` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 Bug fixes
 * `visc_load_pdata()` now works in `datapackage` mode for installed datapackages that use `LazyData: true` in their DESCRIPTION file (#293)
+* `visc_load_pdata()` now also works with standard evaluation, accepting a character string as its first argument (#295)
 
 Improvements for package contributors and maintainers
 * Fix Codecov badge and URL (#287)

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -1,10 +1,9 @@
 #' @title Load a VISC pdata object and check version by datapackage or hash
 #' @description Allows for loading a pdata object either from active project
-#'   repo (during review) or from the library installed location. This
-#'   facilitates task switching when transitioning from ad hoc review to
+#'   repo (during review) or from the libarary installed location. This
+#'   facilitates task switching when transitioning from adhoc review to
 #'   production reporting.
-#' @param .data pdata name as a string e.g. "PKGNAME_ASSAY". Using an
-#'   unquoted name e.g. PKGNAME_ASSAY is deprecated and throws a warning.
+#' @param .data pdata name e.g. PKGNAME_ASSAY
 #' @param proj_or_datapackage whether to load the data from the current project
 #'   repo or an installed datapackage
 #' @param criteria 32 digit hash or data package version 0.1.X.
@@ -12,19 +11,19 @@
 #' @examples
 #' \dontrun{
 #' # default behavior: loads a pdata from the currently installed package, no criteria checking
-#' visc_load_pdata("Hassell750_ics")
+#' visc_load_pdata(Hassell750_ics)
 #'
 #' ## add a check against hash
-#' visc_load_pdata("Hassell750_ics", criteria = "4f054442a6549bffcd947af4b0da9155")
+#' visc_load_pdata(Hassell750_ics, criteria = "4f054442a6549bffcd947af4b0da9155")
 #' ## add a check against dataversion
-#' visc_load_pdata("Hassell750_ics", criteria = "0.1.68")
+#' visc_load_pdata(Hassell750_ics, criteria = "0.1.68")
 #'
 #'
 #' # load a pdata from the active project repo, not installed
-#' visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj")
+#' visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj")
 #'
 #' ## add check against hash
-#' visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj",
+#' visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj",
 #'   criteria = "09ab8a5a3831e854d21144d89557ccb1")
 #' ## skips criteria check if looking at datapackage
 #' }
@@ -33,22 +32,7 @@ visc_load_pdata <- function(.data,
                             proj_or_datapackage = "datapackage",
                             criteria = NULL){
 
-  if (is.name(substitute(.data))){
-    pdata_name <- deparse(substitute(.data))
-    warning(
-      sprintf(
-        paste('visc_load_pdata: Providing the `.data` argument as unquoted %s',
-              'is deprecated. Please use quoted "%s" going forward.'
-        ),
-        pdata_name, pdata_name
-      )
-    )
-  } else if (is.character(.data)){
-    pdata_name <- .data
-  } else {
-    stop('.data must be a character string or an unquoted object name')
-  }
-
+  pdata_name <- deparse(substitute(.data))
   pkg_name <- strsplit(pdata_name, "_")[[1]][1]
 
   # r/o picnic

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -1,9 +1,9 @@
 #' @title Load a VISC pdata object and check version by datapackage or hash
 #' @description Allows for loading a pdata object either from active project
-#'   repo (during review) or from the libarary installed location. This
-#'   facilitates task switching when transitioning from adhoc review to
+#'   repo (during review) or from the library installed location. This
+#'   facilitates task switching when transitioning from ad hoc review to
 #'   production reporting.
-#' @param .data pdata name e.g. PKGNAME_ASSAY
+#' @param .data pdata as name or character, e.g., PKGNAME_ASSAY or "PKGNAME_ASSAY"
 #' @param proj_or_datapackage whether to load the data from the current project
 #'   repo or an installed datapackage
 #' @param criteria 32 digit hash or data package version 0.1.X.
@@ -31,8 +31,12 @@
 visc_load_pdata <- function(.data,
                             proj_or_datapackage = "datapackage",
                             criteria = NULL){
+  pdata_name <- if (is.name(substitute(.data))){
+    deparse(substitute(.data))
+  } else if (is.character(.data)){
+    .data
+  } else stop('`.data` must be an unquoted name or a character string')
 
-  pdata_name <- deparse(substitute(.data))
   pkg_name <- strsplit(pdata_name, "_")[[1]][1]
 
   # r/o picnic

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -1,9 +1,10 @@
 #' @title Load a VISC pdata object and check version by datapackage or hash
 #' @description Allows for loading a pdata object either from active project
-#'   repo (during review) or from the libarary installed location. This
-#'   facilitates task switching when transitioning from adhoc review to
+#'   repo (during review) or from the library installed location. This
+#'   facilitates task switching when transitioning from ad hoc review to
 #'   production reporting.
-#' @param .data pdata name e.g. PKGNAME_ASSAY
+#' @param .data pdata name as a string e.g. "PKGNAME_ASSAY". Using an
+#'   unquoted name e.g. PKGNAME_ASSAY is deprecated and throws a warning.
 #' @param proj_or_datapackage whether to load the data from the current project
 #'   repo or an installed datapackage
 #' @param criteria 32 digit hash or data package version 0.1.X.
@@ -11,19 +12,19 @@
 #' @examples
 #' \dontrun{
 #' # default behavior: loads a pdata from the currently installed package, no criteria checking
-#' visc_load_pdata(Hassell750_ics)
+#' visc_load_pdata("Hassell750_ics")
 #'
 #' ## add a check against hash
-#' visc_load_pdata(Hassell750_ics, criteria = "4f054442a6549bffcd947af4b0da9155")
+#' visc_load_pdata("Hassell750_ics", criteria = "4f054442a6549bffcd947af4b0da9155")
 #' ## add a check against dataversion
-#' visc_load_pdata(Hassell750_ics, criteria = "0.1.68")
+#' visc_load_pdata("Hassell750_ics", criteria = "0.1.68")
 #'
 #'
 #' # load a pdata from the active project repo, not installed
-#' visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj")
+#' visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj")
 #'
 #' ## add check against hash
-#' visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj",
+#' visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj",
 #'   criteria = "09ab8a5a3831e854d21144d89557ccb1")
 #' ## skips criteria check if looking at datapackage
 #' }
@@ -32,7 +33,22 @@ visc_load_pdata <- function(.data,
                             proj_or_datapackage = "datapackage",
                             criteria = NULL){
 
-  pdata_name <- deparse(substitute(.data))
+  if (is.name(substitute(.data))){
+    pdata_name <- deparse(substitute(.data))
+    warning(
+      sprintf(
+        paste('visc_load_pdata: Providing the `.data` argument as unquoted %s',
+              'is deprecated. Please use quoted "%s" going forward.'
+        ),
+        pdata_name, pdata_name
+      )
+    )
+  } else if (is.character(.data)){
+    pdata_name <- .data
+  } else {
+    stop('.data must be a character string or an unquoted object name')
+  }
+
   pkg_name <- strsplit(pdata_name, "_")[[1]][1]
 
   # r/o picnic

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -7,7 +7,8 @@
 visc_load_pdata(.data, proj_or_datapackage = "datapackage", criteria = NULL)
 }
 \arguments{
-\item{.data}{pdata name e.g. PKGNAME_ASSAY}
+\item{.data}{pdata name as a string e.g. "PKGNAME_ASSAY". Using an
+unquoted name e.g. PKGNAME_ASSAY is deprecated and throws a warning.}
 
 \item{proj_or_datapackage}{whether to load the data from the current project
 repo or an installed datapackage}
@@ -19,26 +20,26 @@ pdata object
 }
 \description{
 Allows for loading a pdata object either from active project
-repo (during review) or from the libarary installed location. This
-facilitates task switching when transitioning from adhoc review to
+repo (during review) or from the library installed location. This
+facilitates task switching when transitioning from ad hoc review to
 production reporting.
 }
 \examples{
 \dontrun{
 # default behavior: loads a pdata from the currently installed package, no criteria checking
-visc_load_pdata(Hassell750_ics)
+visc_load_pdata("Hassell750_ics")
 
 ## add a check against hash
-visc_load_pdata(Hassell750_ics, criteria = "4f054442a6549bffcd947af4b0da9155")
+visc_load_pdata("Hassell750_ics", criteria = "4f054442a6549bffcd947af4b0da9155")
 ## add a check against dataversion
-visc_load_pdata(Hassell750_ics, criteria = "0.1.68")
+visc_load_pdata("Hassell750_ics", criteria = "0.1.68")
 
 
 # load a pdata from the active project repo, not installed
-visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj")
+visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj")
 
 ## add check against hash
-visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj",
+visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj",
   criteria = "09ab8a5a3831e854d21144d89557ccb1")
 ## skips criteria check if looking at datapackage
 }

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -7,7 +7,7 @@
 visc_load_pdata(.data, proj_or_datapackage = "datapackage", criteria = NULL)
 }
 \arguments{
-\item{.data}{pdata name e.g. PKGNAME_ASSAY}
+\item{.data}{pdata as name or character, e.g., PKGNAME_ASSAY or "PKGNAME_ASSAY"}
 
 \item{proj_or_datapackage}{whether to load the data from the current project
 repo or an installed datapackage}
@@ -19,8 +19,8 @@ pdata object
 }
 \description{
 Allows for loading a pdata object either from active project
-repo (during review) or from the libarary installed location. This
-facilitates task switching when transitioning from adhoc review to
+repo (during review) or from the library installed location. This
+facilitates task switching when transitioning from ad hoc review to
 production reporting.
 }
 \examples{

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -7,8 +7,7 @@
 visc_load_pdata(.data, proj_or_datapackage = "datapackage", criteria = NULL)
 }
 \arguments{
-\item{.data}{pdata name as a string e.g. "PKGNAME_ASSAY". Using an
-unquoted name e.g. PKGNAME_ASSAY is deprecated and throws a warning.}
+\item{.data}{pdata name e.g. PKGNAME_ASSAY}
 
 \item{proj_or_datapackage}{whether to load the data from the current project
 repo or an installed datapackage}
@@ -20,26 +19,26 @@ pdata object
 }
 \description{
 Allows for loading a pdata object either from active project
-repo (during review) or from the library installed location. This
-facilitates task switching when transitioning from ad hoc review to
+repo (during review) or from the libarary installed location. This
+facilitates task switching when transitioning from adhoc review to
 production reporting.
 }
 \examples{
 \dontrun{
 # default behavior: loads a pdata from the currently installed package, no criteria checking
-visc_load_pdata("Hassell750_ics")
+visc_load_pdata(Hassell750_ics)
 
 ## add a check against hash
-visc_load_pdata("Hassell750_ics", criteria = "4f054442a6549bffcd947af4b0da9155")
+visc_load_pdata(Hassell750_ics, criteria = "4f054442a6549bffcd947af4b0da9155")
 ## add a check against dataversion
-visc_load_pdata("Hassell750_ics", criteria = "0.1.68")
+visc_load_pdata(Hassell750_ics, criteria = "0.1.68")
 
 
 # load a pdata from the active project repo, not installed
-visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj")
+visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj")
 
 ## add check against hash
-visc_load_pdata("Hassell750_ics", proj_or_datapackage = "proj",
+visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj",
   criteria = "09ab8a5a3831e854d21144d89557ccb1")
 ## skips criteria check if looking at datapackage
 }

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -15,10 +15,22 @@ test_that("visc_load_pdata works", {
   })
   expect_equal(basename(pb_res), "Visc777_1.0.tar.gz")
   # test with local source "project" datapackage
+  # right hash, deprecation warning for unquoted pdata name
+  expect_warning(
+    expect_no_error(
+      suppressMessages({
+        proj_loaded_pdata <- visc_load_pdata(Visc777_cars,
+                                             'proj',
+                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+        )
+      })
+    ),
+    "deprecated"
+  )
   # right hash
   expect_no_error(
     suppressMessages({
-      proj_loaded_pdata <- visc_load_pdata(Visc777_cars,
+      proj_loaded_pdata <- visc_load_pdata('Visc777_cars',
                             'proj',
                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
       )
@@ -28,7 +40,7 @@ test_that("visc_load_pdata works", {
   # wrong hash
   expect_error(
     suppressMessages({
-      visc_load_pdata(Visc777_cars,
+      visc_load_pdata('Visc777_cars',
                                            'proj',
                                            'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
       )
@@ -38,7 +50,7 @@ test_that("visc_load_pdata works", {
   # test with installed data package
   withr::with_temp_libpaths({
     # friendly error message when data package not yet installed
-    expect_error(visc_load_pdata(Visc777_cars,
+    expect_error(visc_load_pdata('Visc777_cars',
                     'datapackage',
                     '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'),
                  'Data package.*not installed'
@@ -56,7 +68,7 @@ test_that("visc_load_pdata works", {
     # right hash
     expect_no_error(
       suppressMessages({
-        pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
+        pkg_loaded_pdata <- visc_load_pdata('Visc777_cars',
                                             'datapackage',
                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
         )
@@ -65,7 +77,7 @@ test_that("visc_load_pdata works", {
     # wrong hash
     expect_error(
       suppressMessages({
-        visc_load_pdata(Visc777_cars,
+        visc_load_pdata('Visc777_cars',
                         'datapackage',
                         'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
         )
@@ -79,7 +91,7 @@ test_that("visc_load_pdata works", {
     expect_error(
       suppressMessages({
         suppressWarnings({
-          visc_load_pdata(Visc777_cars,
+          visc_load_pdata('Visc777_cars',
                           'datapackage',
                           '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
           )
@@ -106,7 +118,7 @@ test_that("visc_load_pdata works", {
     # right hash
     expect_no_error(
       suppressMessages({
-        pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
+        pkg_loaded_pdata <- visc_load_pdata('Visc777_cars',
                                             'datapackage',
                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
         )
@@ -115,7 +127,7 @@ test_that("visc_load_pdata works", {
     # wrong hash
     expect_error(
       suppressMessages({
-        visc_load_pdata(Visc777_cars,
+        visc_load_pdata('Visc777_cars',
                         'datapackage',
                         'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
         )

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -15,22 +15,10 @@ test_that("visc_load_pdata works", {
   })
   expect_equal(basename(pb_res), "Visc777_1.0.tar.gz")
   # test with local source "project" datapackage
-  # right hash, deprecation warning for unquoted pdata name
-  expect_warning(
-    expect_no_error(
-      suppressMessages({
-        proj_loaded_pdata <- visc_load_pdata(Visc777_cars,
-                                             'proj',
-                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
-        )
-      })
-    ),
-    "deprecated"
-  )
   # right hash
   expect_no_error(
     suppressMessages({
-      proj_loaded_pdata <- visc_load_pdata('Visc777_cars',
+      proj_loaded_pdata <- visc_load_pdata(Visc777_cars,
                             'proj',
                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
       )
@@ -40,7 +28,7 @@ test_that("visc_load_pdata works", {
   # wrong hash
   expect_error(
     suppressMessages({
-      visc_load_pdata('Visc777_cars',
+      visc_load_pdata(Visc777_cars,
                                            'proj',
                                            'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
       )
@@ -50,7 +38,7 @@ test_that("visc_load_pdata works", {
   # test with installed data package
   withr::with_temp_libpaths({
     # friendly error message when data package not yet installed
-    expect_error(visc_load_pdata('Visc777_cars',
+    expect_error(visc_load_pdata(Visc777_cars,
                     'datapackage',
                     '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'),
                  'Data package.*not installed'
@@ -68,7 +56,7 @@ test_that("visc_load_pdata works", {
     # right hash
     expect_no_error(
       suppressMessages({
-        pkg_loaded_pdata <- visc_load_pdata('Visc777_cars',
+        pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
                                             'datapackage',
                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
         )
@@ -77,7 +65,7 @@ test_that("visc_load_pdata works", {
     # wrong hash
     expect_error(
       suppressMessages({
-        visc_load_pdata('Visc777_cars',
+        visc_load_pdata(Visc777_cars,
                         'datapackage',
                         'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
         )
@@ -91,7 +79,7 @@ test_that("visc_load_pdata works", {
     expect_error(
       suppressMessages({
         suppressWarnings({
-          visc_load_pdata('Visc777_cars',
+          visc_load_pdata(Visc777_cars,
                           'datapackage',
                           '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
           )
@@ -118,7 +106,7 @@ test_that("visc_load_pdata works", {
     # right hash
     expect_no_error(
       suppressMessages({
-        pkg_loaded_pdata <- visc_load_pdata('Visc777_cars',
+        pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
                                             'datapackage',
                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
         )
@@ -127,7 +115,7 @@ test_that("visc_load_pdata works", {
     # wrong hash
     expect_error(
       suppressMessages({
-        visc_load_pdata('Visc777_cars',
+        visc_load_pdata(Visc777_cars,
                         'datapackage',
                         'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
         )

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -15,6 +15,34 @@ test_that("visc_load_pdata works", {
   })
   expect_equal(basename(pb_res), "Visc777_1.0.tar.gz")
   # test with local source "project" datapackage
+  # wrong `.data` class
+  expect_error(
+    suppressMessages({
+      proj_loaded_pdata <- visc_load_pdata(2L, 'proj')
+    }),
+    'must be an unquoted name or a character string'
+  )
+  # right hash, character string pdata argument
+  expect_no_error(
+    suppressMessages({
+      proj_loaded_pdata <- visc_load_pdata('Visc777_cars',
+                                           'proj',
+                                           '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+      )
+    })
+  )
+  # right hash, character string pdata argument, used in other code
+  expect_no_error(
+    suppressMessages({
+      res <- lapply(
+        rep('Visc777_cars', 2),
+        visc_load_pdata,
+        proj_or_datapackage = 'proj',
+        criteria = '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+      )
+    })
+  )
+  expect_length(res, 2)
   # right hash
   expect_no_error(
     suppressMessages({


### PR DESCRIPTION
## Description

`visc_load_pdata()` uses non-standard evaluation for its `.data` argument, requiring an unquoted name to be passed.

This requirement goes against the grain of how R functions typically work and makes it hard to use with other code.

Internally, it's calling `deparse(substitute(...))` on the unquoted thing that you gave it, and this is fragile in R.

For example:

```
> lapply(c('ID52Frahm_bama_bds', 'ID52Frahm_ics'), visc_load_pdata, proj_or_datapackage = 'proj')
Error in readChar(con, 5L, useBytes = TRUE) : cannot open the connection
In addition: Warning messages:
1: In FUN(X[[i]], ...) : No criteria provided. Ignoring data check
2: In readChar(con, 5L, useBytes = TRUE) :
  cannot open compressed file '/home/dslager/repos/ID52Frahm/data/X[[i]].rda', probable reason 'No such file or directory'
```

In this PR, the original behavior still works and it also works when you pass the pdata name as a character string.  This allows for functional/programming usage, like the above lapply() example.

## Checklist

- [x] This PR includes unit tests
- [x] This PR establishes a new function or updates parameters in an existing function
  - [x]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
