### PR TITLE
visc_load_pdata: Make dataVersion defunct and allow loading pdata with a non-standard name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # VISCtemplates (development version)
 
-Other improvements
+Improvements for users
 * `visc_load_pdata()` no longer accepts a dataVersion (e.g. `0.1.2`) as its `criteria` argument. Use a 32-digit data hash, as has long been standard practice. (#297)
+* `visc_load_pdata()` gains a new optional `package` argument for loading pdata with a non-standard name. (#297)
 
 # VISCtemplates 2.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # VISCtemplates (development version)
 
+Other improvements
+* `visc_load_pdata()` no longer accepts a dataVersion (e.g. `0.1.2`) as its `criteria` argument. Use a 32-digit data hash, as has long been standard practice. (#297)
+
 # VISCtemplates 2.0.1
 
 Bug fixes

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -83,18 +83,21 @@ visc_load_pdata <- function(.data,
   message("Loading ", pdata_name, " from ", proj_or_datapackage)
   pdata <- get(pdata_name, envir = pdata_env)
 
-  # Check for a valid data hash, then verify against provided data hash
+  # if criteria missing, skip check. Warn, but return pdata anyway
   if (is.null(criteria)) {
     warning("No criteria provided. Ignoring data check")
-    # if criteria is not a valid hash, skip check but load pdata anyway
-  } else if (!grepl("^[0-9a-f]{32}$", criteria)) {
-    warning("Ignoring criteria check. Incorrect criteria syntax provided.")
-    criteria <- NULL
-  } else {
-    pdata_digest <- digest::digest(pdata)
-    testthat::expect_equal(pdata_digest, criteria)
-    message("Hash: ", criteria, " matches!")
+    return(pdata)
   }
 
+  # if criteria not a valid hash, skip check. Warn, but return pdata anyway
+  if (! grepl("^[0-9a-f]{32}$", criteria)) {
+    warning("Ignoring criteria check. Incorrect criteria syntax provided.")
+    return(pdata)
+  }
+
+  # return pdata if hash check is successful
+  pdata_digest <- digest::digest(pdata)
+  testthat::expect_equal(pdata_digest, criteria)
+  message("Hash: ", criteria, " matches!")
   return(pdata)
 }

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -1,12 +1,19 @@
 #' @title Load a VISC pdata object and check data hash
 #' @description Allows for loading a pdata object either from active project
-#'   repo (during review) or from the library installed location. This
+#'   repo (e.g., during review) or from the library installed location. This
 #'   facilitates task switching when transitioning from ad hoc review to
 #'   production reporting.
-#' @param .data pdata as name or character, e.g., PKGNAME_ASSAY or "PKGNAME_ASSAY"
-#' @param proj_or_datapackage whether to load the data from the current project
-#'   repo or an installed datapackage
-#' @param criteria character, a 32-digit hexadecimal data hash with lowercase letters
+#' @param .data pdata as name or character, e.g., PKGNAME_ASSAY or
+#'   "PKGNAME_ASSAY"
+#' @param proj_or_datapackage whether to load the data from an installed
+#'   datapackage (`datapackage`, the default) or the current project repo
+#'   (`proj` or `repo`)
+#' @param criteria character, a 32-digit hexadecimal data hash with lowercase
+#'   letters
+#' @param package only used in `datapackage` mode. NULL (default; standard VISC
+#'   pdata naming) or character. If NULL, look for pdata named `.data` in
+#'   package <portion of `.data` before the first underscore>. If not NULL, look
+#'   for pdata named `.data` in package `package`.
 #' @return pdata object
 #' @examples
 #' \dontrun{
@@ -27,35 +34,40 @@
 #' @export
 visc_load_pdata <- function(.data,
                             proj_or_datapackage = "datapackage",
-                            criteria = NULL){
+                            criteria = NULL,
+                            package = NULL){
+
+  # switch for pdata given as name or character
   pdata_name <- if (is.name(substitute(.data))){
     deparse(substitute(.data))
   } else if (is.character(.data)){
     .data
   } else stop('`.data` must be an unquoted name or a character string')
 
-  pkg_name <- strsplit(pdata_name, "_")[[1]][1]
-
-  # r/o picnic
-  if (is.null(criteria)) {
-    warning("No criteria provided. Ignoring data check")
-  } else if (!grepl("^[0-9a-f]{32}$", criteria)) {
-    warning("Ignoring criteria check. Incorrect criteria syntax provided.")
-    criteria <- NULL
-  }
-
+  # data() loads pdata into this environment before returning
   pdata_env <- new.env(parent = emptyenv())
+
+  # switch for proj/repo mode vs. installed datapackage mode
   if(tolower(proj_or_datapackage) %in% c("proj", "repo")){
-    # data package project / source folder method
+    # project / source repo mode
     load(DataPackageR::project_data_path(paste0(pdata_name, ".rda")),
          envir = pdata_env)
-
   } else {
-    # installed datapackage method
+    # installed datapackage mode
+
+    # switch for standard/non-standard pdata naming
+    if (is.null(package)){
+      pkg_name <- strsplit(pdata_name, "_")[[1]][1]
+    } else {
+      pkg_name <- package
+    }
+
+    # check package is installed
     if (! pkg_name %in% rownames(utils::installed.packages())){
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
     utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
+    # check data was in the package
     if (! exists(pdata_name, pdata_env)){
       stop(
         sprintf(
@@ -67,15 +79,22 @@ visc_load_pdata <- function(.data,
     }
   }
 
+  # extract pdata from temporary environment
   message("Loading ", pdata_name, " from ", proj_or_datapackage)
   pdata <- get(pdata_name, envir = pdata_env)
 
-  if(! is.null(criteria)){
+  # Check for a valid data hash, then verify against provided data hash
+  if (is.null(criteria)) {
+    warning("No criteria provided. Ignoring data check")
+    # if criteria is not a valid hash, skip check but load pdata anyway
+  } else if (!grepl("^[0-9a-f]{32}$", criteria)) {
+    warning("Ignoring criteria check. Incorrect criteria syntax provided.")
+    criteria <- NULL
+  } else {
     pdata_digest <- digest::digest(pdata)
     testthat::expect_equal(pdata_digest, criteria)
     message("Hash: ", criteria, " matches!")
   }
 
   return(pdata)
-
 }

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -1,4 +1,4 @@
-#' @title Load a VISC pdata object and check version by datapackage or hash
+#' @title Load a VISC pdata object and check data hash
 #' @description Allows for loading a pdata object either from active project
 #'   repo (during review) or from the library installed location. This
 #'   facilitates task switching when transitioning from ad hoc review to
@@ -6,7 +6,7 @@
 #' @param .data pdata as name or character, e.g., PKGNAME_ASSAY or "PKGNAME_ASSAY"
 #' @param proj_or_datapackage whether to load the data from the current project
 #'   repo or an installed datapackage
-#' @param criteria 32 digit hash or data package version 0.1.X.
+#' @param criteria character, a 32-digit hexadecimal data hash with lowercase letters
 #' @return pdata object
 #' @examples
 #' \dontrun{
@@ -15,9 +15,6 @@
 #'
 #' ## add a check against hash
 #' visc_load_pdata(Hassell750_ics, criteria = "4f054442a6549bffcd947af4b0da9155")
-#' ## add a check against dataversion
-#' visc_load_pdata(Hassell750_ics, criteria = "0.1.68")
-#'
 #'
 #' # load a pdata from the active project repo, not installed
 #' visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj")
@@ -42,16 +39,9 @@ visc_load_pdata <- function(.data,
   # r/o picnic
   if (is.null(criteria)) {
     warning("No criteria provided. Ignoring data check")
-  } else if(tolower(proj_or_datapackage) %in% c("proj", "repo") &&
-            grepl(pattern = "0\\.1\\.\\d{1,2}", criteria)){
-    warning("Ignoring criteria check. Criteria is from data version but source is repo.",
-            "Did you mean to use the hash criteria?")
-    criteria <- NULL
-  } else if (nchar(criteria) != 32 &
-             !grepl(pattern = "0\\.1\\.\\d{1,2}", criteria)) {
+  } else if (!grepl("^[0-9a-f]{32}$", criteria)) {
     warning("Ignoring criteria check. Incorrect criteria syntax provided.")
     criteria <- NULL
-
   }
 
   pdata_env <- new.env(parent = emptyenv())
@@ -80,16 +70,10 @@ visc_load_pdata <- function(.data,
   message("Loading ", pdata_name, " from ", proj_or_datapackage)
   pdata <- get(pdata_name, envir = pdata_env)
 
-  if(!is.null(criteria)){
-    if(nchar(criteria) == 32){
-      pdata_digest <- digest::digest(pdata)
-      testthat::expect_equal(pdata_digest,
-                             criteria)
-      message("Hash: ", criteria, " matches!")
-    } else {
-      DataPackageR::assert_data_version(pkg_name, version_string = criteria)
-      message("Asserted data version: ", criteria)
-    }
+  if(! is.null(criteria)){
+    pdata_digest <- digest::digest(pdata)
+    testthat::expect_equal(pdata_digest, criteria)
+    message("Hash: ", criteria, " matches!")
   }
 
   return(pdata)

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -33,9 +33,10 @@
 #' }
 #' @export
 visc_load_pdata <- function(.data,
-                            proj_or_datapackage = "datapackage",
+                            proj_or_datapackage = c("datapackage", "proj", "repo"),
                             criteria = NULL,
                             package = NULL){
+  proj_or_datapackage <- match.arg(proj_or_datapackage)
 
   # switch for pdata given as name or character
   pdata_name <- if (is.name(substitute(.data))){

--- a/inst/extdata/tests/subsetCars.Rmd
+++ b/inst/extdata/tests/subsetCars.Rmd
@@ -5,4 +5,5 @@ output: html_document
 
 ```{r}
 Visc777_cars = subset(cars, speed > 20)
+rogue_object <- Visc777_cars
 ```

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/visc_load_pdata.R
 \name{visc_load_pdata}
 \alias{visc_load_pdata}
-\title{Load a VISC pdata object and check version by datapackage or hash}
+\title{Load a VISC pdata object and check data hash}
 \usage{
 visc_load_pdata(.data, proj_or_datapackage = "datapackage", criteria = NULL)
 }
@@ -12,7 +12,7 @@ visc_load_pdata(.data, proj_or_datapackage = "datapackage", criteria = NULL)
 \item{proj_or_datapackage}{whether to load the data from the current project
 repo or an installed datapackage}
 
-\item{criteria}{32 digit hash or data package version 0.1.X.}
+\item{criteria}{character, a 32-digit hexadecimal data hash with lowercase letters}
 }
 \value{
 pdata object
@@ -30,9 +30,6 @@ visc_load_pdata(Hassell750_ics)
 
 ## add a check against hash
 visc_load_pdata(Hassell750_ics, criteria = "4f054442a6549bffcd947af4b0da9155")
-## add a check against dataversion
-visc_load_pdata(Hassell750_ics, criteria = "0.1.68")
-
 
 # load a pdata from the active project repo, not installed
 visc_load_pdata(Hassell750_ics, proj_or_datapackage = "proj")

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -6,7 +6,7 @@
 \usage{
 visc_load_pdata(
   .data,
-  proj_or_datapackage = "datapackage",
+  proj_or_datapackage = c("datapackage", "proj", "repo"),
   criteria = NULL,
   package = NULL
 )

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -4,22 +4,35 @@
 \alias{visc_load_pdata}
 \title{Load a VISC pdata object and check data hash}
 \usage{
-visc_load_pdata(.data, proj_or_datapackage = "datapackage", criteria = NULL)
+visc_load_pdata(
+  .data,
+  proj_or_datapackage = "datapackage",
+  criteria = NULL,
+  package = NULL
+)
 }
 \arguments{
-\item{.data}{pdata as name or character, e.g., PKGNAME_ASSAY or "PKGNAME_ASSAY"}
+\item{.data}{pdata as name or character, e.g., PKGNAME_ASSAY or
+"PKGNAME_ASSAY"}
 
-\item{proj_or_datapackage}{whether to load the data from the current project
-repo or an installed datapackage}
+\item{proj_or_datapackage}{whether to load the data from an installed
+datapackage (\code{datapackage}, the default) or the current project repo
+(\code{proj} or \code{repo})}
 
-\item{criteria}{character, a 32-digit hexadecimal data hash with lowercase letters}
+\item{criteria}{character, a 32-digit hexadecimal data hash with lowercase
+letters}
+
+\item{package}{only used in \code{datapackage} mode. NULL (default; standard VISC
+pdata naming) or character. If NULL, look for pdata named \code{.data} in
+package <portion of \code{.data} before the first underscore>. If not NULL, look
+for pdata named \code{.data} in package \code{package}.}
 }
 \value{
 pdata object
 }
 \description{
 Allows for loading a pdata object either from active project
-repo (during review) or from the library installed location. This
+repo (e.g., during review) or from the library installed location. This
 facilitates task switching when transitioning from ad hoc review to
 production reporting.
 }

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -183,3 +183,67 @@ test_that("visc_load_pdata works", {
     )
   })
 })
+
+test_that('visc_load_pdata works with non-standard pdata name', {
+  td <- withr::local_tempdir()
+  file <- system.file("extdata", "tests", "subsetCars.Rmd",
+                      package = "VISCtemplates"
+  )
+  DataPackageR::datapackage_skeleton(
+    name = "Visc777",
+    path = td,
+    code_files = file,
+    r_object_names = c("rogue_object", "Visc777_cars")
+  )
+  # test using project repo
+  suppressMessages({
+    DataPackageR::package_build(
+      file.path(td, "Visc777")
+    )
+  })
+  # Even for rogue object with non-standard naming, don't need to provide
+  # package override in proj/repo mode
+  expect_no_error(
+    suppressMessages(
+      rogue_object <- visc_load_pdata(
+        'rogue_object',
+        'proj',
+        '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+      )
+    )
+  )
+  # test using pdata from installed datapackage
+  withr::with_temp_libpaths({
+    suppressMessages({
+      DataPackageR::package_build(
+        file.path(td, "Visc777"), install = TRUE, quiet = TRUE
+      )
+    })
+    standard_object_path <- file.path(td, 'data', 'Visc777_cars.rda')
+    file.copy(
+      standard_object_path,
+      file.path(td, 'data', 'rogue_object.rda')
+    )
+    unlink(standard_object_path)
+    # right hash, rogue object handled
+    expect_no_error(
+      suppressMessages(
+        rogue_object <- visc_load_pdata(
+          'rogue_object',
+          'datapackage',
+          '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3',
+          'Visc777'
+        )
+      )
+    )
+    # should be identical to rogue_object, based on test Rmd file
+    suppressMessages(
+      Visc777_cars <- visc_load_pdata(
+        'Visc777_cars',
+        'datapackage',
+        '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+      )
+    )
+    expect_identical(rogue_object, Visc777_cars)
+  })
+})

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -14,6 +14,27 @@ test_that("visc_load_pdata works", {
     pb_res <- DataPackageR::package_build(file.path(td, "Visc777"))
   })
   expect_equal(basename(pb_res), "Visc777_1.0.tar.gz")
+  # warn when criteria = NULL
+  expect_warning(
+    suppressMessages({
+      visc_load_pdata(Visc777_cars, 'proj')
+    }),
+    'No criteria provided'
+  )
+  # warn when criteria is dataVersion in 'proj' mode
+  expect_warning(
+    suppressMessages({
+      visc_load_pdata(Visc777_cars, 'proj', '0.1.3')
+    }),
+    'Criteria is from data version but source is repo'
+  )
+  # warn when criteria is unexpected
+  expect_warning(
+    suppressMessages({
+      visc_load_pdata(Visc777_cars, 'proj', 'yo')
+    }),
+    'Incorrect criteria syntax provided'
+  )
   # test with local source "project" datapackage
   # wrong `.data` class
   expect_error(
@@ -87,6 +108,15 @@ test_that("visc_load_pdata works", {
         pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
                                             'datapackage',
                                             '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
+        )
+      })
+    )
+    # right hash, dataVersion mode
+    expect_no_error(
+      suppressMessages({
+        pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
+                                            'datapackage',
+                                            '0.1.0'
         )
       })
     )

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -21,12 +21,12 @@ test_that("visc_load_pdata works", {
     }),
     'No criteria provided'
   )
-  # warn when criteria is dataVersion in 'proj' mode
+  # warn when criteria given as dataVersion (defunct, now ignores check)
   expect_warning(
     suppressMessages({
       visc_load_pdata(Visc777_cars, 'proj', '0.1.3')
     }),
-    'Criteria is from data version but source is repo'
+    'Ignoring criteria check'
   )
   # warn when criteria is unexpected
   expect_warning(
@@ -111,14 +111,15 @@ test_that("visc_load_pdata works", {
         )
       })
     )
-    # right hash, dataVersion mode
-    expect_no_error(
+    # right hash, dataVersion given (defunct, now ignores check)
+    expect_warning(
       suppressMessages({
         pkg_loaded_pdata <- visc_load_pdata(Visc777_cars,
                                             'datapackage',
                                             '0.1.0'
         )
-      })
+      }),
+      "Ignoring criteria check"
     )
     # wrong hash
     expect_error(

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -219,12 +219,6 @@ test_that('visc_load_pdata works with non-standard pdata name', {
         file.path(td, "Visc777"), install = TRUE, quiet = TRUE
       )
     })
-    standard_object_path <- file.path(td, 'data', 'Visc777_cars.rda')
-    file.copy(
-      standard_object_path,
-      file.path(td, 'data', 'rogue_object.rda')
-    )
-    unlink(standard_object_path)
     # right hash, rogue object handled
     expect_no_error(
       suppressMessages(


### PR DESCRIPTION
## Description

Add unit tests to cover the rest of the code branches in `visc_load_pdata()`, remove dataVersion criteria method per discussion at last VISCtemplates meeting, and allow reading in pdata with a non-standard name by way of the new optional `package` argument.

## Checklist

- [x] This PR includes unit tests
- [x] This PR establishes a new function or updates parameters in an existing function
  - [x]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
