### PR TITLE
More specific visc_load_pdata() error message when pdata R object name differs from pdata file name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # VISCtemplates (development version)
 
+Improvements for users
+* `visc_load_pdata()` gives more informative error message when serialized pdata file does not contain an R object of the same name (#303)
+
 # VISCtemplates 2.0.2
 
 Improvements for users

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -49,7 +49,7 @@ visc_load_pdata <- function(.data,
   pdata_env <- new.env(parent = emptyenv())
 
   # switch for proj/repo mode vs. installed datapackage mode
-  if(tolower(proj_or_datapackage) %in% c("proj", "repo")){
+  if(proj_or_datapackage %in% c("proj", "repo")){
     # project / source repo mode
     load(DataPackageR::project_data_path(paste0(pdata_name, ".rda")),
          envir = pdata_env)

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -73,16 +73,17 @@ visc_load_pdata <- function(.data,
       # load pdata_name from data package
       utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
     )
-    # check R object
-    if (! exists(pdata_name, pdata_env)){
-      stop(
-        sprintf(
-          "Data file `%s` exists but does not contain an R object named `%s`",
-          pdata_name,
-          pdata_name
-        )
+  }
+
+  # check R object name same as pdata file name
+  if (! exists(pdata_name, pdata_env)){
+    stop(
+      sprintf(
+        "Data file `%s` exists but does not contain an R object named `%s`",
+        pdata_name,
+        pdata_name
       )
-    }
+    )
   }
 
   # extract pdata from temporary environment

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -67,14 +67,19 @@ visc_load_pdata <- function(.data,
     if (! pkg_name %in% rownames(utils::installed.packages())){
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
-    utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
-    # check data was in the package
+    withr::with_options(
+      # create error from warning if pdata_name doesn't exist in package
+      list(warn = 2),
+      # load pdata_name from data package
+      utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
+    )
+    # check R object
     if (! exists(pdata_name, pdata_env)){
       stop(
         sprintf(
-          "Unable to find data object '%s' in package '%s'",
+          "Data file `%s` exists but does not contain an R object named `%s`",
           pdata_name,
-          pkg_name
+          pdata_name
         )
       )
     }

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -131,9 +131,12 @@ test_that("visc_load_pdata works", {
       }),
       "pdata_digest.*not equal to.*criteria.*expected"
     )
-    # right hash but errors out when can't find the data/object.rda file
-    file.remove(
-      system.file(file.path('data', "Visc777_cars.rda"), package = 'Visc777')
+    # errors out when can't find the data/object.rda file
+    expect_error(
+      suppressMessages({
+          visc_load_pdata(Visc777_cars_BAD, 'datapackage')
+      }),
+      "data set .* not found"
     )
     expect_error(
       suppressMessages({

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -138,16 +138,14 @@ test_that("visc_load_pdata works", {
       }),
       "data set .* not found"
     )
+    # errors out when data file exists but doesn't contain namesake R object
+    my_pi <- pi
+    save(my_pi, file = system.file(file.path('data', "Visc777_cars.rda"), package = 'Visc777'))
     expect_error(
       suppressMessages({
-        suppressWarnings({
-          visc_load_pdata(Visc777_cars,
-                          'datapackage',
-                          '3ccb5b0aaa74fe7cfc0d3ca6ab0b5cf3'
-          )
-        })
+        visc_load_pdata(Visc777_cars, 'datapackage')
       }),
-      "Unable to find data object.*"
+      "exists but does not contain an R object named"
     )
     # Reinstall package with LazyData: true in DESCRIPTION field
     desc_path <- file.path(td, "Visc777", "DESCRIPTION")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Closes #302.  New error message:

```
> data(lumc_luminex_adata, package = 'ID52Frahm')
> exists('lumc_luminex_adata')
[1] FALSE
> exists('mgia_luminex_outbound')
[1] TRUE
> VISCtemplates::visc_load_pdata('lumc_luminex_adata', 'datapackage', package = 'ID52Frahm')
Error in VISCtemplates::visc_load_pdata("lumc_luminex_adata", "datapackage",  : 
  Data file `lumc_luminex_adata` exists but does not contain an R object named `lumc_luminex_adata`
```

## Checklist

- [x] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
