### PR TITLE
Reduce clutter from package-specific files in analysis repos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
 Encoding: UTF-8
 URL: https://github.com/FredHutch/VISCtemplates
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Suggests: 
     conflicted,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 Improvements for users
 * `visc_load_pdata()` gives more informative error message when serialized pdata file does not contain an R object of the same name (#303)
+* Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
 
 # VISCtemplates 2.0.2
 

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -5,6 +5,8 @@
 #' @param path file path
 #' @param interactive TRUE by default. FALSE is for non-interactive unit testing
 #'   only.
+#' @param is_package FALSE by default. Set to TRUE if your project is an R package
+#' and you want package-specific files (DESCRIPTION, NAMESPACE) to be initiated.
 #'
 #' @return opens a new RStudio session with template project directory
 #' @export

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -8,7 +8,7 @@
 #'
 #' @return opens a new RStudio session with template project directory
 #' @export
-create_visc_project <- function(path, interactive = TRUE){
+create_visc_project <- function(path, interactive = TRUE, is_package = FALSE){
 
   challenge_directory(path, interactive)
 
@@ -29,12 +29,20 @@ create_visc_project <- function(path, interactive = TRUE){
   on.exit(options(usethis.quiet = old_usethis_quiet))
   options(usethis.quiet = ! interactive)
 
-  # create package
-  usethis::create_package(
-    path = path,
-    rstudio = TRUE,
-    open = interactive
-  )
+  # create project
+  if (is_package) {
+    usethis::create_package(
+      path = path,
+      rstudio = TRUE,
+      open = interactive
+    )
+  } else {
+    usethis::create_project(
+      path = path,
+      rstudio = TRUE,
+      open = interactive
+    )
+  }
 
   # must set active project otherwise it is <no active project>
   usethis::proj_set(path = path)

--- a/R/create_visc_project.R
+++ b/R/create_visc_project.R
@@ -5,12 +5,12 @@
 #' @param path file path
 #' @param interactive TRUE by default. FALSE is for non-interactive unit testing
 #'   only.
-#' @param is_package FALSE by default. Set to TRUE if your project is an R package
+#' @param package FALSE by default. Set TRUE to create project as an R package
 #' and you want package-specific files (DESCRIPTION, NAMESPACE) to be initiated.
 #'
 #' @return opens a new RStudio session with template project directory
 #' @export
-create_visc_project <- function(path, interactive = TRUE, is_package = FALSE){
+create_visc_project <- function(path, interactive = TRUE, package = FALSE){
 
   challenge_directory(path, interactive)
 
@@ -32,19 +32,14 @@ create_visc_project <- function(path, interactive = TRUE, is_package = FALSE){
   options(usethis.quiet = ! interactive)
 
   # create project
-  if (is_package) {
-    usethis::create_package(
+  do.call(
+    if (package) usethis::create_package else usethis::create_project,
+    list(
       path = path,
       rstudio = TRUE,
       open = interactive
     )
-  } else {
-    usethis::create_project(
-      path = path,
-      rstudio = TRUE,
-      open = interactive
-    )
-  }
+  )
 
   # must set active project otherwise it is <no active project>
   usethis::proj_set(path = path)

--- a/man/create_visc_project.Rd
+++ b/man/create_visc_project.Rd
@@ -4,7 +4,7 @@
 \alias{create_visc_project}
 \title{Create a VISC project}
 \usage{
-create_visc_project(path, interactive = TRUE)
+create_visc_project(path, interactive = TRUE, is_package = FALSE)
 }
 \arguments{
 \item{path}{file path}

--- a/man/create_visc_project.Rd
+++ b/man/create_visc_project.Rd
@@ -11,6 +11,9 @@ create_visc_project(path, interactive = TRUE, is_package = FALSE)
 
 \item{interactive}{TRUE by default. FALSE is for non-interactive unit testing
 only.}
+
+\item{is_package}{FALSE by default. Set to TRUE if your project is an R package
+and you want package-specific files (DESCRIPTION, NAMESPACE) to be initiated.}
 }
 \value{
 opens a new RStudio session with template project directory

--- a/man/create_visc_project.Rd
+++ b/man/create_visc_project.Rd
@@ -4,7 +4,7 @@
 \alias{create_visc_project}
 \title{Create a VISC project}
 \usage{
-create_visc_project(path, interactive = TRUE, is_package = FALSE)
+create_visc_project(path, interactive = TRUE, package = FALSE)
 }
 \arguments{
 \item{path}{file path}
@@ -12,7 +12,7 @@ create_visc_project(path, interactive = TRUE, is_package = FALSE)
 \item{interactive}{TRUE by default. FALSE is for non-interactive unit testing
 only.}
 
-\item{is_package}{FALSE by default. Set to TRUE if your project is an R package
+\item{package}{FALSE by default. Set TRUE to create project as an R package
 and you want package-specific files (DESCRIPTION, NAMESPACE) to be initiated.}
 }
 \value{

--- a/tests/testthat/test-create_visc_project.R
+++ b/tests/testthat/test-create_visc_project.R
@@ -13,3 +13,13 @@ test_that("create_visc_project works", {
     file.exists(file.path(temp_dir, 'README.html'))
   )
 })
+
+test_that("create_visc_project works in package mode", {
+  # creates ephemeral directory that will be deleted upon function exit
+  temp_dir <- withr::local_tempdir()
+  create_visc_project(temp_dir, interactive = FALSE, package = TRUE)
+  # check that DESCRIPTION got created
+  expect_true(
+    file.exists(file.path(temp_dir, 'DESCRIPTION'))
+  )
+})

--- a/tests/testthat/test-create_visc_project.R
+++ b/tests/testthat/test-create_visc_project.R
@@ -1,4 +1,4 @@
-test_that("create_visc_project works", {
+test_that("create_visc_project works as expected in default mode", {
   # creates ephemeral directory that will be deleted upon function exit
   temp_dir <- withr::local_tempdir()
   create_visc_project(temp_dir, interactive = FALSE)
@@ -12,14 +12,24 @@ test_that("create_visc_project works", {
   expect_false(
     file.exists(file.path(temp_dir, 'README.html'))
   )
+  # verify that package-specific files are not created
+  expect_false(
+    file.exists(file.path(temp_dir, 'DESCRIPTION'))
+  )
+  expect_false(
+    file.exists(file.path(temp_dir, 'NAMESPACE'))
+  )
 })
 
-test_that("create_visc_project works in package mode", {
+test_that("create_visc_project works in pacakge mode", {
   # creates ephemeral directory that will be deleted upon function exit
   temp_dir <- withr::local_tempdir()
   create_visc_project(temp_dir, interactive = FALSE, package = TRUE)
-  # check that DESCRIPTION got created
+  # check for package-specific files
   expect_true(
     file.exists(file.path(temp_dir, 'DESCRIPTION'))
+  )
+  expect_true(
+    file.exists(file.path(temp_dir, 'NAMESPACE'))
   )
 })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This PR changes `create_visc_project()` to call `usethis::create_project()` by default instead of `usethis::create_package()`, so that VISC analysis repos no longer have have the clutter of package-specific files DESCRIPTION and NAMESPACE. The old behavior can still be recreated if desired by using option `is_package = TRUE`.

Here is how the folder is structured when calling `create_visc_project("ExamplePackage", is_package = TRUE)`:
<img width="263" height="385" alt="Screenshot 2025-09-12 at 4 28 35 PM" src="https://github.com/user-attachments/assets/b8f6a666-917c-4647-8f58-59f65983563c" />
and here is how the folder is structured when calling `create_visc_project("ExampleProject")`:
<img width="243" height="340" alt="Screenshot 2025-09-12 at 4 28 51 PM" src="https://github.com/user-attachments/assets/eff3dde3-897b-4785-88fa-f2901762be73" />

## Related Issues

https://github.com/FredHutch/VISCtemplates/issues/299

## Checklist

- [x] This PR includes unit tests
- [x] This PR establishes a new function or updates parameters in an existing function
  - [x]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
