### PR TITLE
Update "methods" folder name to "child-docs"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # VISCtemplates (development version)
 
 Improvements for users
+* Change name of `methods` folder within each report subfolder to `child-docs` to be more general-purpose (#309)
 * `visc_load_pdata()` gives more informative error message when serialized pdata file does not contain an R object of the same name (#303)
 * Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
 

--- a/R/use_visc_report.R
+++ b/R/use_visc_report.R
@@ -148,7 +148,7 @@ use_visc_methods <- function(path = ".", assay = c("generic", "bama", "nab", "ad
 
   pkg_ver <- utils::packageVersion("VISCtemplates")
 
-  usethis::use_directory(file.path(path, "methods"))
+  usethis::use_directory(file.path(path, "child-docs"))
 
   usethis::use_template(
     template = file.path(
@@ -156,7 +156,7 @@ use_visc_methods <- function(path = ".", assay = c("generic", "bama", "nab", "ad
       paste0(assay, "-statistical-methods.Rmd")
       ),
     data = list(pkg_ver = pkg_ver),
-    save_as = file.path(path, "methods", "statistical-methods.Rmd"),
+    save_as = file.path(path, "child-docs", "statistical-methods.Rmd"),
     package = "VISCtemplates"
   )
 
@@ -166,7 +166,7 @@ use_visc_methods <- function(path = ".", assay = c("generic", "bama", "nab", "ad
       paste0(assay, "-lab-methods.Rmd")
       ),
     data = list(pkg_ver = pkg_ver),
-    save_as = file.path(path, "methods", "lab-methods.Rmd"),
+    save_as = file.path(path, "child-docs", "lab-methods.Rmd"),
     package = "VISCtemplates"
   )
 
@@ -176,7 +176,7 @@ use_visc_methods <- function(path = ".", assay = c("generic", "bama", "nab", "ad
       paste0(assay, "-biological-endpoints.Rmd")
       ),
     data = list(pkg_ver = pkg_ver),
-    save_as = file.path(path, "methods", "biological-endpoints.Rmd"),
+    save_as = file.path(path, "child-docs", "biological-endpoints.Rmd"),
     package = "VISCtemplates"
   )
 

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -195,17 +195,17 @@ Objectives can be found on ATLAS, in the study protocol, or in the SAP.
 
 # Biological Endpoints
 
-```{r biological-endpoints, child="methods/biological-endpoints.Rmd"}
+```{r biological-endpoints, child="child-docs/biological-endpoints.Rmd"}
 ```
 
 # Lab Methods
 
-```{r lab-methods, child="methods/lab-methods.Rmd"}
+```{r lab-methods, child="child-docs/lab-methods.Rmd"}
 ```
 
 # Statistical Methods
 
-```{r statistical-methods, child="methods/statistical-methods.Rmd"}
+```{r statistical-methods, child="child-docs/statistical-methods.Rmd"}
 ```
 
 ```{r response-testing, warning=FALSE}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Within each report folder, change name of "methods" folder to "child-docs" (since often additional child Rmd documents are included here).

## Related Issues

https://github.com/FredHutch/VISCtemplates/issues/229

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
