### PR TITLE
Add option to drop SCHARP logo in PDF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 Improvements for users
 * `visc_load_pdata()` gives more informative error message when serialized pdata file does not contain an R object of the same name (#303)
 * Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
+* Add option to drop SCHARP logo in PDF output (#312)
 
 # VISCtemplates 2.0.2
 

--- a/inst/templates/report_latex_template.tex
+++ b/inst/templates/report_latex_template.tex
@@ -249,6 +249,7 @@ $else$
 \fancyhead[C]{\includegraphics[height=0.8cm]{$logo_path_visc$}}
 $endif$
 $if(dropSCHARPlogo)$
+\fancyhead[R]{}
 $else$
 \fancyhead[R]{\includegraphics[height=0.8cm]{$logo_path_scharp$}}
 $endif$

--- a/inst/templates/report_latex_template.tex
+++ b/inst/templates/report_latex_template.tex
@@ -248,7 +248,10 @@ $if(dropVISClogo)$
 $else$
 \fancyhead[C]{\includegraphics[height=0.8cm]{$logo_path_visc$}}
 $endif$
+$if(dropSCHARPlogo)$
+$else$
 \fancyhead[R]{\includegraphics[height=0.8cm]{$logo_path_scharp$}}
+$endif$
 \fancyfoot[C]{Page \thepage{}~of~\pageref{LastPage}}
 \setlength{\headheight}{27pt}
 

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -24,6 +24,7 @@ lof: true
 lot: true
 toc: true
 dropVISClogo: false
+dropSCHARPlogo: false
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -27,7 +27,7 @@ lof: true
 lot: true
 toc: true
 dropVISClogo: false
-dropSCHARPlogo: true
+dropSCHARPlogo: false
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -24,7 +24,7 @@ lof: true
 lot: true
 toc: true
 dropVISClogo: false
-dropSCHARPlogo: false
+dropSCHARPlogo: true
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -24,6 +24,7 @@ lof: true
 lot: true
 toc: true
 dropVISClogo: false
+dropSCHARPlogo: false
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -27,7 +27,7 @@ lof: true
 lot: true
 toc: true
 dropVISClogo: false
-dropSCHARPlogo: true
+dropSCHARPlogo: false
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -24,7 +24,7 @@ lof: true
 lot: true
 toc: true
 dropVISClogo: false
-dropSCHARPlogo: false
+dropSCHARPlogo: true
 output: 
   VISCtemplates::visc_pdf_document: default
   VISCtemplates::visc_word_document: default


### PR DESCRIPTION
## Description

Add option to drop SCHARP logo in PDF, as with VISC logo.

## Related Issues

https://github.com/FredHutch/VISCtemplates/issues/292

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
