### PR TITLE
Repair unit tests to work with testthat 3.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ Improvements for users
 * `visc_load_pdata()` gives more informative error message when serialized pdata file does not contain an R object of the same name (#303)
 * Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
 
+Improvements for package contributors and maintainers
+* Repair unit tests to work with `testthat 3.3.0` (#317)
+
 # VISCtemplates 2.0.2
 
 Improvements for users

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -64,8 +64,7 @@ test_knit_report <- function(report_type, outfile_ext){
             c(CI = NA),
             # we also don't want warnings about initial snapshots
             suppressWarnings({
-              # Use dummy function to always approve the comparison
-              expect_snapshot_file(outfile_path, compare = function(a, b) TRUE)
+              expect_snapshot_file(outfile_path)
             })
           )
         }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -64,7 +64,8 @@ test_knit_report <- function(report_type, outfile_ext){
             c(CI = NA),
             # we also don't want warnings about initial snapshots
             suppressWarnings({
-              expect_snapshot_file(outfile_path)
+              # Use dummy function to always approve the comparison
+              expect_snapshot_file(outfile_path, compare = function(a, b) TRUE)
             })
           )
         }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -53,7 +53,7 @@ test_knit_report <- function(report_type, outfile_ext){
       pdf = c('pdf', 'log', 'tex', 'md', 'Rmd', 'knit.md'),
       docx = c('docx', 'md', 'knit.md', 'Rmd')
     )[[outfile_ext]]
-    snapshot_dir <- file.path(getwd(), test_path('_snaps'))
+    snapshot_dir <- file.path(getwd(), test_path('_snaps', 'use_visc_report'))
     if (! dir.exists(snapshot_dir)){
       dir.create(snapshot_dir, showWarnings = FALSE, recursive = TRUE)
     }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -57,10 +57,16 @@ test_knit_report <- function(report_type, outfile_ext){
       for (ext in try_snapshot_ext){
         outfile_path <- paste0(outfile_sans_ext, '.', ext)
         if (file.exists(outfile_path)){
-          suppressWarnings({
-            # don't want to see warning about initial snapshots
-            expect_snapshot_file(outfile_path)
-          })
+          # testthat v. 3.3.0 errors out on CI when there is no initial snapshot
+          # https://github.com/r-lib/testthat/pull/2149
+          # Trick it into thinking we're not on CI when we're on CI
+          withr::with_envvar(
+            c(CI = NA),
+            # we also don't want warnings about initial snapshots
+            suppressWarnings({
+              expect_snapshot_file(outfile_path)
+            })
+          )
         }
       }
     })

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -53,7 +53,7 @@ test_knit_report <- function(report_type, outfile_ext){
       pdf = c('pdf', 'log', 'tex', 'md', 'Rmd', 'knit.md'),
       docx = c('docx', 'md', 'knit.md', 'Rmd')
     )[[outfile_ext]]
-    snapshot_dir <- file.path(getwd(), test_path('_snaps', 'use_visc_report'))
+    snapshot_dir <- file.path(getwd(), test_path('_snaps'))
     if (! dir.exists(snapshot_dir)){
       dir.create(snapshot_dir, showWarnings = FALSE, recursive = TRUE)
     }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -57,16 +57,10 @@ test_knit_report <- function(report_type, outfile_ext){
       for (ext in try_snapshot_ext){
         outfile_path <- paste0(outfile_sans_ext, '.', ext)
         if (file.exists(outfile_path)){
-          # testthat v. 3.3.0 errors out on CI when there is no initial snapshot
-          # https://github.com/r-lib/testthat/pull/2149
-          # Trick it into thinking we're not on CI when we're on CI
-          withr::with_envvar(
-            c(CI = NA),
-            # we also don't want warnings about initial snapshots
-            suppressWarnings({
-              expect_snapshot_file(outfile_path)
-            })
-          )
+          suppressWarnings({
+            # don't want to see warning about initial snapshots
+            expect_snapshot_file(outfile_path)
+          })
         }
       }
     })

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -53,16 +53,19 @@ test_knit_report <- function(report_type, outfile_ext){
       pdf = c('pdf', 'log', 'tex', 'md', 'Rmd', 'knit.md'),
       docx = c('docx', 'md', 'knit.md', 'Rmd')
     )[[outfile_ext]]
-    local({
-      for (ext in try_snapshot_ext){
-        outfile_path <- paste0(outfile_sans_ext, '.', ext)
-        if (file.exists(outfile_path)){
-          suppressWarnings({
-            # don't want to see warning about initial snapshots
-            expect_snapshot_file(outfile_path)
-          })
-        }
+    snapshot_dir <- file.path(getwd(), test_path('_snaps', 'use_visc_report'))
+    if (! dir.exists(snapshot_dir)){
+      dir.create(snapshot_dir, showWarnings = FALSE, recursive = TRUE)
+    }
+    for (ext in try_snapshot_ext){
+      outfile_path <- paste0(outfile_sans_ext, '.', ext)
+      if (file.exists(outfile_path)){
+        file.copy(outfile_path, snapshot_dir)
+        # avoid our custom snapshots from getting auto-deleted by testthat
+        announce_snapshot_file(
+          file.path(snapshot_dir, basename(outfile_path))
+        )
       }
-    })
+    }
   })
 }

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -81,8 +81,7 @@ test_that("visc_load_pdata works", {
                                            'proj',
                                            'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
       )
-    }),
-    "pdata_digest.*not equal to.*criteria.*expected"
+    })
   )
   # test with installed data package
   withr::with_temp_libpaths({
@@ -128,8 +127,7 @@ test_that("visc_load_pdata works", {
                         'datapackage',
                         'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
         )
-      }),
-      "pdata_digest.*not equal to.*criteria.*expected"
+      })
     )
     # errors out when can't find the data/object.rda file
     expect_error(
@@ -179,8 +177,7 @@ test_that("visc_load_pdata works", {
                         'datapackage',
                         'fffb5b0aaa74fe7cfc0d3ca6ab0bffff'
         )
-      }),
-      "pdata_digest.*not equal to.*criteria.*expected"
+      })
     )
   })
 })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Closes #316. The release of testthat 3.3.0 had broken our unit tests by changing default error messages and by disallowing new file snapshots on CI. This PR makes those unit tests less fussy about exact wording and copies files to `_snaps` manually instead of using the testthat function.

## Checklist

- [x] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes

## Recommended Reviewer action

Also check that snapshots are successfully produced locally/interactively with `devtools::test()`.