### PR TITLE
Remove empty "examples" from template study schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Improvements for users
 
 Improvements for package contributors and maintainers
 * Repair unit tests to work with `testthat 3.3.0` (#317)
+* Remove empty "examples" in template study schema to avoid minor issues (#319)
 
 # VISCtemplates 2.0.2
 

--- a/inst/templates/visc-project-study-schema.R
+++ b/inst/templates/visc-project-study-schema.R
@@ -7,8 +7,6 @@
 #'
 #' @return a kable table with the study schema
 #' @export
-#'
-#' @examples
 study_schema <- function(caption = "{{ study_name }} study schema.") {
 
   schema_table <- tibble::tribble(


### PR DESCRIPTION
## Description

Remove empty "examples" from template study schema.

## Related Issues

https://github.com/FredHutch/VISCtemplates/issues/285

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
