### PR TITLE
test knit in callr session

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ URL: https://github.com/FredHutch/VISCtemplates
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
 RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
-Suggests: 
+Suggests:
+    callr,
     conflicted,
     dplyr,
     flextable,

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Improvements for users
 
 Improvements for package contributors and maintainers
 * Repair unit tests to work with `testthat 3.3.0` (#317)
+* Run test knits in a `callr` session to isolate Rmd library calls from main R process (#320)
 
 # VISCtemplates 2.0.2
 

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -37,12 +37,22 @@ test_knit_report <- function(report_type, outfile_ext){
                       report_type = report_type,
                       interactive = FALSE
       )
-      expect_no_error(
-        rmarkdown::render(file.path(report_name, paste0(report_name, '.Rmd')),
-                          output_format = output_format,
-                          quiet = TRUE,
-                          clean = FALSE)
+      # test knit in a separate R session
+      rs <- callr::r_session$new()
+      on.exit(rs$close(), add = TRUE)
+      res <- rs$run_with_output(
+        function(...) rmarkdown::render(envir = globalenv(), ...),
+        args = list(
+          file.path(report_name, paste0(report_name, '.Rmd')),
+          output_format = output_format,
+          quiet = TRUE,
+          clean = FALSE
+        )
       )
+      # propagate full error stack from subprocess into main process
+      if (!is.null(res$error)) {
+        stop(paste(capture.output(res$error), collapse = '\n'))
+      }
     })
     outfile_sans_ext <- file.path(temp_dir, report_name, report_name)
     expect_true(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Test knitting now occurs in a separate R process, like what happens when pressing the "Knit" button in Rstudio. This prevents library calls in the skeleton Rmd file from affecting the rest of the unit tests.

Closes #275.

## See also

DPR2, where we implemented something similar for reproducibility

https://github.com/FredHutch/DPR2/pull/52

## Checklist

- [x] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
