### PR TITLE
Use standard library calls in template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Improvements for users
 * Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
 * Add option to drop SCHARP logo in PDF output (#312)
 * Add `visc_load_pdata()` examples to report template skeleton (#327)
+* Remove `install_load_cran_packages()` from report template skeleton in favor of using `library()` calls (#321)
 
 Improvements for package contributors and maintainers
 

--- a/R/report_functions.R
+++ b/R/report_functions.R
@@ -7,7 +7,7 @@
 #'
 #' @examples
 #' \dontrun{load_install_cran_packages(c("tidyr", "dplyr"))}
-install_load_cran_packages <- function(packages) {
+install_load_cran_packages <- function(packages) { #nocov start
   installed_packages <- rownames(utils::installed.packages())
   lapply(packages, FUN = function(package) {
     if (! package %in% installed_packages) {
@@ -33,7 +33,7 @@ install_load_cran_packages <- function(packages) {
     library(package, character.only = TRUE)
   })
   invisible(NULL)
-}
+} # nocov end
 
 #' Check pandoc version
 #'

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -45,18 +45,21 @@ Location of input data:
 
 ```{r package-loading-and-options, include=FALSE}
 
-# packages installed from GitHub
+# load packages
 library(VISCtemplates)
 library(VISCfunctions)
+library(conflicted)
+library(dplyr)
+library(ggplot2)
+library(knitr)
+library(kableExtra)
+library(flextable)
+library(rprojroot)
 
 check_pandoc_version()
 output_type <- get_output_type()
 kable_warnings <- set_kable_warnings(output_type)
 pandoc_markup <- set_pandoc_markup(output_type)
-
-# packages installed from CRAN
-packages_needed <- c("conflicted", "dplyr", "ggplot2", "knitr", "kableExtra", "flextable", "rprojroot")
-install_load_cran_packages(packages_needed)
 
 # knitr options
 opts_chunk$set(cache = FALSE,

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -62,10 +62,6 @@ output_type <- get_output_type()
 kable_warnings <- set_kable_warnings(output_type)
 pandoc_markup <- set_pandoc_markup(output_type)
 
-# where to install and look for packages (e.g., data packages) installed on SCHARP server
-my_data_package_lib <- "/Volumes/kmacphee/RLib/" # UPDATE WITH YOUR DATA PACKAGE LOCATION
-.libPaths(c(.libPaths(), my_data_package_lib))
-
 # knitr options
 opts_chunk$set(cache = FALSE,
                message = TRUE,

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -45,18 +45,22 @@ Location of input data:
 
 ```{r package-loading-and-options, include=FALSE}
 
-# packages installed from GitHub
+# load packages
 library(VISCtemplates)
 library(VISCfunctions)
+library(conflicted)
+library(ggplot2)
+library(dplyr)
+library(knitr)
+library(kableExtra)
+library(flextable)
+library(rprojroot)
+library(remotes)
 
 check_pandoc_version()
 output_type <- get_output_type()
 kable_warnings <- set_kable_warnings(output_type)
 pandoc_markup <- set_pandoc_markup(output_type)
-
-# packages installed from CRAN
-packages_needed <- c("conflicted", "ggplot2", "dplyr", "knitr", "kableExtra", "flextable", "rprojroot", "remotes")
-install_load_cran_packages(packages_needed)
 
 # where to install and look for packages (e.g., data packages) installed on SCHARP server
 my_data_package_lib <- "/Volumes/kmacphee/RLib/" # UPDATE WITH YOUR DATA PACKAGE LOCATION

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -129,6 +129,18 @@ install_git_workaround(
   git = 'external'
 )
 
+# install datapackage from SCHARP server to your designated datapackage_path()
+install_git_workaround(
+  networks_path("cavd/Studies/cvd920/pdata/Caskey920.git"),
+  ref = "main",
+  git = "external"
+  # `force` required if you've already installed the package w/ same hash
+  # (even if installed to a different directory), because
+  # `remotes::install_git` checks hash before passing `lib` to install.packages
+  force = TRUE,
+  lib = datapackage_path()
+)
+
 ```
 
 ```{r data-loading, eval = FALSE}
@@ -149,6 +161,14 @@ exampleData_ICS <- visc_load_pdata(
   proj_or_datapackage = 'datapackage',
   criteria = 'a70bc33ea70bc33ea70bc33ea70bc33e',
   package = 'cvdNNN'
+)
+
+# load pdata from datapackage installed to your designated datapackage_path()
+pdata <- visc_load_pdata(
+  "Caskey920_nab",
+  "datapackage",
+  "34b189faa034f29dbb0692d4676ab56f",
+  lib.loc = datapackage_path()
 )
 
 ```


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

The idea here is to keep the function but to use standard library calls in the template Rmd rather than installing/loading with a custom function.

## See also

The `renv` package, for a more fine-grained and reproducible way to install required R packages & versions.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
