### PR TITLE
Auto-generate VISCtemplates website with pkgdown/GH actions 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,6 @@ CONTRIBUTING.md
 ^\.github$
 ^tests/testthat/_snaps
 ^tests/testthat/_snaps/use_visc_report
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Meta
 inst/doc
 tests/testthat/_snaps/use_visc_report/
 .DS_store
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     remotes,
     VISCfunctions
 Encoding: UTF-8
-URL: https://github.com/FredHutch/VISCtemplates
+URL: https://github.com/FredHutch/VISCtemplates, https://fredhutch.github.io/VISCtemplates/
 BugReports: https://github.com/FredHutch/VISCtemplates/issues
 RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://fredhutch.github.io/VISCtemplates/
+template:
+  bootstrap: 5
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Draft PR for auto-generated VISCtemplates website.  You can preview the built site locally from this branch with `pkgdown::build_site()`.

## Related Issues

#313 
https://github.com/FredHutch/VISCfunctions/pull/119

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
