### PR TITLE
drop dependency on DataPackageR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ License: GPL-3 + file LICENSE
 Depends: R (>= 3.0)
 Imports:
     fs,
-    DataPackageR,
     digest,
     bookdown,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Improvements for package contributors and maintainers
 * Repair unit tests to work with `testthat 3.3.0` (#317)
 * Remove empty "examples" in template study schema to avoid minor issues (#319)
 * Run test knits in a `callr` session to isolate Rmd library calls from main R process (#320)
+* Drop dependency on `DataPackageR` (#324)
 
 # VISCtemplates 2.0.2
 

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -51,7 +51,7 @@ visc_load_pdata <- function(.data,
   # switch for proj/repo mode vs. installed datapackage mode
   if(proj_or_datapackage %in% c("proj", "repo")){
     # project / source repo mode
-    load(DataPackageR::project_data_path(paste0(pdata_name, ".rda")),
+    load(rprojroot::find_package_root_file("data", paste0(pdata_name, ".rda")),
          envir = pdata_env)
   } else {
     # installed datapackage mode

--- a/inst/extdata/tests/subsetCars.Rmd
+++ b/inst/extdata/tests/subsetCars.Rmd
@@ -1,9 +1,0 @@
----
-title: "A Test Document for visc_load_pdata"
-output: html_document
----
-
-```{r}
-Visc777_cars = subset(cars, speed > 20)
-rogue_object <- Visc777_cars
-```

--- a/inst/templates/report_latex_template.tex
+++ b/inst/templates/report_latex_template.tex
@@ -49,11 +49,6 @@
 \usepackage{soul} % Hyphenation for letterspacing, underlining, and more
 \usepackage{relsize} % Set the font size relative to the current font size
 
-% Add unicode checkmark for DataPackageR support. The green checkmark
-% that DataPackageR prints to the console during package_build() causes
-% an error with latex. This changes the unicode checkmark to a latex one.
-\DeclareUnicodeCharacter{2714}{\checkmark}
-
 % page settings
 \setlength{\footskip}{56pt}
 \pagestyle{fancy}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,15 +1,3 @@
-# use these options for testthat tests, interactively or non-interactively,
-# and restore previously set options when tests are finished
-# https://testthat.r-lib.org/articles/special-files.html
-withr::local_options(
-  list(
-    DataPackageR_interact = FALSE,
-    DataPackageR_packagebuilding = FALSE,
-    DataPackageR_verbose = FALSE
-  ),
-  .local_envir = teardown_env()
-)
-
 # Delete existing report template snapshots before testing. These are binary
 # files that change with each knit, so we don't want to programmatically compare
 # them and we only want to save the fresh ones. This, along with adding this

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -1,19 +1,23 @@
 test_that("visc_load_pdata works", {
+  old_usethis_quiet <- getOption('usethis.quiet')
+  on.exit(options(usethis.quiet = old_usethis_quiet), add = TRUE)
+  options(usethis.quiet = TRUE)
   # make and build test datapackage
   td <- withr::local_tempdir()
-  file <- system.file("extdata", "tests", "subsetCars.Rmd",
-                      package = "VISCtemplates"
+  usethis::create_package(
+    path = file.path(td, "Visc777"),
+    rstudio = FALSE,
+    open = FALSE
   )
-  DataPackageR::datapackage_skeleton(
-    name = "Visc777",
-    path = td,
-    code_files = file,
-    r_object_names = "Visc777_cars"
+  dir.create(file.path(td, 'Visc777', 'data'), recursive = TRUE)
+  Visc777_cars <- subset(cars, speed > 20)
+  save(
+    Visc777_cars,
+    file = file.path(td, 'Visc777', 'data', 'Visc777_cars.rda')
   )
-  suppressMessages({
-    pb_res <- DataPackageR::package_build(file.path(td, "Visc777"))
-  })
-  expect_equal(basename(pb_res), "Visc777_1.0.tar.gz")
+
+  # test using project repo
+  withr::local_dir(file.path(td, "Visc777"))
   # warn when criteria = NULL
   expect_warning(
     suppressMessages({
@@ -92,10 +96,9 @@ test_that("visc_load_pdata works", {
                  'Data package.*not installed'
     )
     # install
-    suppressMessages({
-      pb_res <- DataPackageR::package_build(file.path(td, "Visc777"),
-                                            install = TRUE, quiet = TRUE)
-    })
+    utils::install.packages(
+      file.path(td, "Visc777"), repo = NULL, quiet = TRUE
+    )
     # test RDA style package data installation
     expect_equal(
         'Visc777_cars.rda',
@@ -150,10 +153,9 @@ test_that("visc_load_pdata works", {
     new_desc <- c(readLines(desc_path), 'LazyData: true')
     writeLines(new_desc, desc_path)
     # do install
-    suppressMessages({
-      pb_res <- DataPackageR::package_build(file.path(td, "Visc777"),
-                                            install = TRUE, quiet = TRUE)
-    })
+    utils::install.packages(
+      file.path(td, "Visc777"), repo = NULL, quiet = TRUE
+    )
     # test LazyData style package data installation
     expect_true(
       setequal(
@@ -183,22 +185,30 @@ test_that("visc_load_pdata works", {
 })
 
 test_that('visc_load_pdata works with non-standard pdata name', {
+  old_usethis_quiet <- getOption('usethis.quiet')
+  on.exit(options(usethis.quiet = old_usethis_quiet), add = TRUE)
+  options(usethis.quiet = TRUE)
+
+  # setup test pkg with standard and non-standard data objects
   td <- withr::local_tempdir()
-  file <- system.file("extdata", "tests", "subsetCars.Rmd",
-                      package = "VISCtemplates"
+  usethis::create_package(
+    path = file.path(td, "Visc777"),
+    rstudio = FALSE,
+    open = FALSE
   )
-  DataPackageR::datapackage_skeleton(
-    name = "Visc777",
-    path = td,
-    code_files = file,
-    r_object_names = c("rogue_object", "Visc777_cars")
+  dir.create(file.path(td, 'Visc777', 'data'), recursive = TRUE)
+  Visc777_cars <- subset(cars, speed > 20)
+  save(
+    Visc777_cars,
+    file = file.path(td, 'Visc777', 'data', 'Visc777_cars.rda')
+  )
+  rogue_object <- Visc777_cars
+  save(
+    rogue_object,
+    file = file.path(td, 'Visc777', 'data', 'rogue_object.rda')
   )
   # test using project repo
-  suppressMessages({
-    DataPackageR::package_build(
-      file.path(td, "Visc777")
-    )
-  })
+  withr::local_dir(file.path(td, 'Visc777'))
   # Even for rogue object with non-standard naming, don't need to provide
   # package override in proj/repo mode
   expect_no_error(
@@ -212,11 +222,9 @@ test_that('visc_load_pdata works with non-standard pdata name', {
   )
   # test using pdata from installed datapackage
   withr::with_temp_libpaths({
-    suppressMessages({
-      DataPackageR::package_build(
-        file.path(td, "Visc777"), install = TRUE, quiet = TRUE
-      )
-    })
+    utils::install.packages(
+      file.path(td, "Visc777"), repo = NULL, quiet = TRUE
+    )
     # right hash, rogue object handled
     expect_no_error(
       suppressMessages(

--- a/tests/testthat/test-visc_load_pdata.R
+++ b/tests/testthat/test-visc_load_pdata.R
@@ -97,7 +97,7 @@ test_that("visc_load_pdata works", {
     )
     # install
     utils::install.packages(
-      file.path(td, "Visc777"), repo = NULL, quiet = TRUE
+      file.path(td, "Visc777"), repo = NULL, type = 'source', quiet = TRUE
     )
     # test RDA style package data installation
     expect_equal(
@@ -154,7 +154,7 @@ test_that("visc_load_pdata works", {
     writeLines(new_desc, desc_path)
     # do install
     utils::install.packages(
-      file.path(td, "Visc777"), repo = NULL, quiet = TRUE
+      file.path(td, "Visc777"), repo = NULL, type = 'source', quiet = TRUE
     )
     # test LazyData style package data installation
     expect_true(
@@ -223,7 +223,7 @@ test_that('visc_load_pdata works with non-standard pdata name', {
   # test using pdata from installed datapackage
   withr::with_temp_libpaths({
     utils::install.packages(
-      file.path(td, "Visc777"), repo = NULL, quiet = TRUE
+      file.path(td, "Visc777"), repo = NULL, type = 'source', quiet = TRUE
     )
     # right hash, rogue object handled
     expect_no_error(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Drops the dependency on `DataPackageR`.

The only change to function code is the line in `visc_load_pdata()` where I've followed the path-finding logic I implemented [earlier](https://github.com/FredHutch/DPR2/blob/c8ea420022808c415ce5ab672a0d926840c558ea/R/utility.R#L258) for `DPR2::dpr_path()`.

## Checklist

- [x] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
