### PR TITLE
Allow long packages tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Improvements for users
 * Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
 * Add option to drop SCHARP logo in PDF output (#312)
 * Add `visc_load_pdata()` examples to report template skeleton (#327)
+* Reproducibility table formatting changes to coordinate with recent VISCfunctions update that lengthens reproducibility packages table to include packages that are loaded but not attached (#329)
 
 Improvements for package contributors and maintainers
 

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -167,7 +167,7 @@ if (output_type == 'latex') {
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
     kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>%
-    kable_styling()
+    kable_styling(latex_options = 'repeat_header')
   
 } else {
   

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -166,7 +166,7 @@ if (output_type == 'latex') {
   
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
-    kable(booktabs = TRUE, linesep = "", caption = tbl_caption) %>% 
+    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>% 
     kable_styling()
   
 } else {

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -134,7 +134,7 @@ if (any(installed.packages()[,1] == 'rmarkdown')) suppressWarnings(library(rmark
 
 my_session_info <- VISCfunctions::get_session_info()
 
-tbl_caption <- "Reproducibility software session information"
+tbl_caption <- "Session reproducibility information"
 
 if (output_type == 'latex') {
   
@@ -162,7 +162,7 @@ if (output_type == 'latex') {
 
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
 
-tbl_caption <- "Reproducibility software package version information"
+tbl_caption <- "Package reproducibility information"
 
 if (output_type == 'latex') {
   

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -166,7 +166,7 @@ if (output_type == 'latex') {
   
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
-    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>% 
+    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>%
     kable_styling()
   
 } else {

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -158,6 +158,8 @@ if (output_type == 'latex') {
 }
 ```
 
+`r insert_break()`
+
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
 
 tbl_caption <- "Reproducibility software package version information"
@@ -170,8 +172,6 @@ if (output_type == 'latex') {
     kable_styling(latex_options = 'repeat_header')
   
 } else {
-  
-  cat(insert_break())
   
   # format nicely for Word with flextable
   my_session_info$packages_table %>%

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -446,7 +446,7 @@ if (output_type == 'latex') {
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
     kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>%
-    kable_styling()
+    kable_styling(latex_options = 'repeat_header')
   
 } else {
   

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -413,7 +413,7 @@ if (any(installed.packages()[,1] == 'rmarkdown')) suppressWarnings(library(rmark
 
 my_session_info <- VISCfunctions::get_session_info()
 
-tbl_caption <- "Reproducibility software session information"
+tbl_caption <- "Session reproducibility information"
 
 if (output_type == 'latex') {
   
@@ -441,7 +441,7 @@ if (output_type == 'latex') {
 
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
 
-tbl_caption <- "Reproducibility software package version information"
+tbl_caption <- "Package reproducibility information"
 
 if (output_type == 'latex') {
   

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -445,7 +445,7 @@ if (output_type == 'latex') {
   
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
-    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>% 
+    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>%
     kable_styling()
   
 } else {

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -437,6 +437,8 @@ if (output_type == 'latex') {
 }
 ```
 
+`r insert_break()`
+
 ```{r Software-Package-Version-Information, results="asis", warning=kable_warnings}
 
 tbl_caption <- "Reproducibility software package version information"
@@ -449,8 +451,6 @@ if (output_type == 'latex') {
     kable_styling(latex_options = 'repeat_header')
   
 } else {
-  
-  cat(insert_break())
   
   # format nicely for Word with flextable
   my_session_info$packages_table %>%

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -445,7 +445,7 @@ if (output_type == 'latex') {
   
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
-    kable(booktabs = TRUE, linesep = "", caption = tbl_caption) %>% 
+    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>% 
     kable_styling()
   
 } else {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Add `longtable = TRUE` to kable options for reproducibility packages tables.

## Related Issues

Related to https://github.com/FredHutch/VISCfunctions/pull/132#pullrequestreview-3546939316 which will make reproducibility packages tables longer.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
