### PR TITLE
Add datapackage_path() variable/function and add `lib.loc` argument to `visc_load_pdata()`

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(check_pandoc_version)
 export(create_visc_project)
+export(datapackage_path)
 export(get_output_type)
 export(insert_break)
 export(insert_ref)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 Improvements for users
 
+* New infrastructure to support installing and loading datapackages from a designated directory (#331)
+  - New function `datapackage_path()` to access `VISCTEMPLATES_DATAPACKAGE_PATH` environment variable
+  - New argument `lib.loc` for `visc_load_pdata()`
 * Remove `check_pandoc_version()` from report templates (#318)
 * New function `install_git_workaround()` to avoid `remotes::install_git()` error on network drive paths (#315)
 * Change name of `methods` folder within each report subfolder to `child-docs` to be more general-purpose (#309)

--- a/R/paths.R
+++ b/R/paths.R
@@ -16,16 +16,20 @@
 #' \preformatted{
 #' VISCTEMPLATES_NETWORKS_PATH="N:"
 #' VISCTEMPLATES_TRIALS_PATH="T:"
+#' VISCTEMPLATES_DATAPACKAGE_PATH="H:/datapackages"
 #' }
 #' \item macOS
 #' \preformatted{
 #' VISCTEMPLATES_NETWORKS_PATH="/Volumes/networks"
 #' VISCTEMPLATES_TRIALS_PATH="/Volumes/trials"
+#' VISCTEMPLATES_DATAPACKAGE_PATH="/Volumes/kmacphee/RLib/"
 #' }
 #' \item Linux
 #' \preformatted{
 #' VISCTEMPLATES_NETWORKS_PATH="/networks"
-#' VISCTEMPLATES_TRIALS_PATH="/trials" }
+#' VISCTEMPLATES_TRIALS_PATH="/trials"
+#' VISCTEMPLATES_DATAPACKAGE_PATH="/home/username/datapackages"
+#' }
 #' }
 #' \item Save the file
 #' \item Restart your R session (in Rstudio: `Session` > `Restart R`)

--- a/R/paths.R
+++ b/R/paths.R
@@ -22,7 +22,7 @@
 #' \preformatted{
 #' VISCTEMPLATES_NETWORKS_PATH="/Volumes/networks"
 #' VISCTEMPLATES_TRIALS_PATH="/Volumes/trials"
-#' VISCTEMPLATES_DATAPACKAGE_PATH="/Volumes/kmacphee/RLib/"
+#' VISCTEMPLATES_DATAPACKAGE_PATH="/Volumes/kmacphee/RLib"
 #' }
 #' \item Linux
 #' \preformatted{

--- a/R/paths.R
+++ b/R/paths.R
@@ -1,15 +1,16 @@
 #' Construct paths
 #'
-#' Requires one-time setup of the environment variable
-#' `VISCTEMPLATES_NETWORKS_PATH` or `VISCTEMPLATES_TRIALS_PATH` in your
-#' `.Renviron` file. To do this,
+#' Requires one-time setup of environment variables
+#' `VISCTEMPLATES_NETWORKS_PATH`, `VISCTEMPLATES_TRIALS_PATH`, and/or
+#' `VISCTEMPLATES_DATAPACKAGE_PATH` in your `.Renviron` file. To do this,
 #' \enumerate{
 #' \item Open your `.Renviron` file for editing in Rstudio
 #' with [usethis::edit_r_environ()]
-#' \item Add needed line(s) to `.Renviron` defining `VISCTEMPLATES_NETWORKS_PATH`
-#' and/or `VISCTEMPLATES_TRIALS_PATH` to reflect your operating system and your
-#' drive mappings. Only use the forward slash `/` as a path
-#' separator and do not use a trailing `/`. Typical settings:
+#' \item Add needed line(s) to `.Renviron` defining
+#' `VISCTEMPLATES_NETWORKS_PATH`, `VISCTEMPLATES_TRIALS_PATH`, and/or
+#' `VISCTEMPLATES_DATAPACKAGE_PATH` to reflect your operating system, drive
+#' mappings, and datapackage install location. Only use the forward slash `/` as
+#' a path separator and do not use a trailing `/`. Typical settings:
 #' \itemize{
 #' \item Windows
 #' \preformatted{
@@ -32,7 +33,7 @@
 #' }
 #'
 #' @param ... additional path components passed to [file.path()]; appended after
-#'   the networks or trials root path defined in your `.Renviron` file
+#'   the networks, trials, or datapackage root path defined in your `.Renviron` file
 #' @name paths
 #' @return Character; the concatenated path
 NULL
@@ -44,6 +45,10 @@ networks_path <- function(...) path_helper('networks', ...)
 #' @rdname paths
 #' @export
 trials_path <- function(...) path_helper('trials', ...)
+
+#' @rdname paths
+#' @export
+datapackage_path <- function(...) path_helper('datapackage', ...)
 
 #' Internal helper function for [networks_path()] and [trials_path()]
 #'

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -71,6 +71,13 @@ visc_load_pdata <- function(.data,
     if (! pkg_name %in% rownames(utils::installed.packages(lib.loc = lib.loc))){
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
+    message(
+      sprintf(
+        'Loading pdata from installed datapackage %s in library %s',
+        pkg_name,
+        dirname(find.package(pkg_name, lib.loc = lib.loc))
+      )
+    )
     withr::with_options(
       # create error from warning if pdata_name doesn't exist in package
       list(warn = 2),

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -14,6 +14,9 @@
 #'   pdata naming) or character. If NULL, look for pdata named `.data` in
 #'   package <portion of `.data` before the first underscore>. If not NULL, look
 #'   for pdata named `.data` in package `package`.
+#' @param lib.loc library path from which to load the data package. Passed
+#'   internally to `utils::data()`. Default is `NULL`, which uses the first
+#'   element of `.libPaths()`
 #' @return pdata object
 #' @examples
 #' \dontrun{
@@ -35,7 +38,8 @@
 visc_load_pdata <- function(.data,
                             proj_or_datapackage = c("datapackage", "proj", "repo"),
                             criteria = NULL,
-                            package = NULL){
+                            package = NULL,
+                            lib.loc = NULL){
   proj_or_datapackage <- match.arg(proj_or_datapackage)
 
   # switch for pdata given as name or character
@@ -64,14 +68,19 @@ visc_load_pdata <- function(.data,
     }
 
     # check package is installed
-    if (! pkg_name %in% rownames(utils::installed.packages())){
+    if (! pkg_name %in% rownames(utils::installed.packages(lib.loc = lib.loc))){
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
     withr::with_options(
       # create error from warning if pdata_name doesn't exist in package
       list(warn = 2),
       # load pdata_name from data package
-      utils::data(list = pdata_name, package = pkg_name, envir = pdata_env)
+      utils::data(
+        list = pdata_name,
+        package = pkg_name,
+        envir = pdata_env,
+        lib.loc = lib.loc
+      )
     )
   }
 

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -55,8 +55,10 @@ visc_load_pdata <- function(.data,
   # switch for proj/repo mode vs. installed datapackage mode
   if(proj_or_datapackage %in% c("proj", "repo")){
     # project / source repo mode
-    load(rprojroot::find_package_root_file("data", paste0(pdata_name, ".rda")),
-         envir = pdata_env)
+    message("Loading ", pdata_name, " from current project/repo")
+    dp <- rprojroot::find_package_root_file("data", paste0(pdata_name, ".rda"))
+    load(dp, envir = pdata_env)
+    message("Found file ", dp)
   } else {
     # installed datapackage mode
 
@@ -73,9 +75,9 @@ visc_load_pdata <- function(.data,
     }
     message(
       sprintf(
-        'Loading pdata from installed datapackage %s in library %s',
-        pkg_name,
-        dirname(find.package(pkg_name, lib.loc = lib.loc))
+        'Loading %s from installed datapackage\nFound library %s',
+        pdata_name,
+        find.package(pkg_name, lib.loc = lib.loc)
       )
     )
     withr::with_options(
@@ -103,7 +105,6 @@ visc_load_pdata <- function(.data,
   }
 
   # extract pdata from temporary environment
-  message("Loading ", pdata_name, " from ", proj_or_datapackage)
   pdata <- get(pdata_name, envir = pdata_env)
 
   # if criteria missing, skip check. Warn, but return pdata anyway
@@ -121,6 +122,6 @@ visc_load_pdata <- function(.data,
   # return pdata if hash check is successful
   pdata_digest <- digest::digest(pdata)
   testthat::expect_equal(pdata_digest, criteria)
-  message("Hash: ", criteria, " matches!")
+  message("Data hash ", criteria, " matches!")
   return(pdata)
 }

--- a/R/visc_load_pdata.R
+++ b/R/visc_load_pdata.R
@@ -68,7 +68,7 @@ visc_load_pdata <- function(.data,
     }
 
     # check package is installed
-    if (! pkg_name %in% rownames(utils::installed.packages(lib.loc = lib.loc))){
+    if (! pkg_name %in% .packages(all.available = TRUE, lib.loc = lib.loc)){
       stop(paste0("Data package '", pkg_name, "' is not installed"))
     }
     message(

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -4,30 +4,34 @@
 \alias{paths}
 \alias{networks_path}
 \alias{trials_path}
+\alias{datapackage_path}
 \title{Construct paths}
 \usage{
 networks_path(...)
 
 trials_path(...)
+
+datapackage_path(...)
 }
 \arguments{
 \item{...}{additional path components passed to \code{\link[=file.path]{file.path()}}; appended after
-the networks or trials root path defined in your \code{.Renviron} file}
+the networks, trials, or datapackage root path defined in your \code{.Renviron} file}
 }
 \value{
 Character; the concatenated path
 }
 \description{
-Requires one-time setup of the environment variable
-\code{VISCTEMPLATES_NETWORKS_PATH} or \code{VISCTEMPLATES_TRIALS_PATH} in your
-\code{.Renviron} file. To do this,
+Requires one-time setup of environment variables
+\code{VISCTEMPLATES_NETWORKS_PATH}, \code{VISCTEMPLATES_TRIALS_PATH}, and/or
+\code{VISCTEMPLATES_DATAPACKAGE_PATH} in your \code{.Renviron} file. To do this,
 \enumerate{
 \item Open your \code{.Renviron} file for editing in Rstudio
 with \code{\link[usethis:edit]{usethis::edit_r_environ()}}
-\item Add needed line(s) to \code{.Renviron} defining \code{VISCTEMPLATES_NETWORKS_PATH}
-and/or \code{VISCTEMPLATES_TRIALS_PATH} to reflect your operating system and your
-drive mappings. Only use the forward slash \code{/} as a path
-separator and do not use a trailing \code{/}. Typical settings:
+\item Add needed line(s) to \code{.Renviron} defining
+\code{VISCTEMPLATES_NETWORKS_PATH}, \code{VISCTEMPLATES_TRIALS_PATH}, and/or
+\code{VISCTEMPLATES_DATAPACKAGE_PATH} to reflect your operating system, drive
+mappings, and datapackage install location. Only use the forward slash \code{/} as
+a path separator and do not use a trailing \code{/}. Typical settings:
 \itemize{
 \item Windows
 \preformatted{

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -37,16 +37,20 @@ a path separator and do not use a trailing \code{/}. Typical settings:
 \preformatted{
 VISCTEMPLATES_NETWORKS_PATH="N:"
 VISCTEMPLATES_TRIALS_PATH="T:"
+VISCTEMPLATES_DATAPACKAGE_PATH="H:/datapackages"
 }
 \item macOS
 \preformatted{
 VISCTEMPLATES_NETWORKS_PATH="/Volumes/networks"
 VISCTEMPLATES_TRIALS_PATH="/Volumes/trials"
+VISCTEMPLATES_DATAPACKAGE_PATH="/Volumes/kmacphee/RLib/"
 }
 \item Linux
 \preformatted{
 VISCTEMPLATES_NETWORKS_PATH="/networks"
-VISCTEMPLATES_TRIALS_PATH="/trials" }
+VISCTEMPLATES_TRIALS_PATH="/trials"
+VISCTEMPLATES_DATAPACKAGE_PATH="/home/username/datapackages"
+}
 }
 \item Save the file
 \item Restart your R session (in Rstudio: \code{Session} > \verb{Restart R})

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -43,7 +43,7 @@ VISCTEMPLATES_DATAPACKAGE_PATH="H:/datapackages"
 \preformatted{
 VISCTEMPLATES_NETWORKS_PATH="/Volumes/networks"
 VISCTEMPLATES_TRIALS_PATH="/Volumes/trials"
-VISCTEMPLATES_DATAPACKAGE_PATH="/Volumes/kmacphee/RLib/"
+VISCTEMPLATES_DATAPACKAGE_PATH="/Volumes/kmacphee/RLib"
 }
 \item Linux
 \preformatted{

--- a/man/visc_load_pdata.Rd
+++ b/man/visc_load_pdata.Rd
@@ -8,7 +8,8 @@ visc_load_pdata(
   .data,
   proj_or_datapackage = c("datapackage", "proj", "repo"),
   criteria = NULL,
-  package = NULL
+  package = NULL,
+  lib.loc = NULL
 )
 }
 \arguments{
@@ -26,6 +27,10 @@ letters}
 pdata naming) or character. If NULL, look for pdata named \code{.data} in
 package <portion of \code{.data} before the first underscore>. If not NULL, look
 for pdata named \code{.data} in package \code{package}.}
+
+\item{lib.loc}{library path from which to load the data package. Passed
+internally to \code{utils::data()}. Default is \code{NULL}, which uses the first
+element of \code{.libPaths()}}
 }
 \value{
 pdata object


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This adds a new `lib.loc` argument to `visc_load_pdata()`, a new .Renviron variable VISCTEMPLATES_DATAPACKAGE_PATH, and a new function datapackage_path() that pulls from that environment variable. The code below demonstrates usage of the `lib`/`lib.loc` arguments from the various functions to install, load, and use data packages and pdata via a "safe" directory.

No unit tests yet, but will include if we end up going this route.

## Demonstration code

```
# install branch of VISCtemplates
# to get install_git_workaround() and new visc_load_pdata()
remotes::install_github('FredHutch/VISCtemplates', ref = 'lib.loc')

# set up your .Renviron to include a VISCTEMPLATES_DATAPACKAGE_PATH according to this helpfile:
?VISCtemplates::datapackage_path
# restart R

library(VISCtemplates)

# create a "safe" datapackage directory if doesn't already exist
dir.create(datapackage_path(), recursive = TRUE, showWarnings = FALSE)

# example installation of networks drive datapackage
networks_package_path <- networks_path(
  'cavd/Studies/cvd920/pdata/Caskey920.git'
)

install_git_workaround(
  networks_package_path,
  # `force` is required if you've already installed the package w/ same hash
  # (even if installed to a different dir), b/c
  # `remotes::install_git` checks hash before passing `lib` to install.packages
  force = TRUE,
  lib = datapackage_path()
)

# example installation of GitHub datapackage

remotes::install_github(
  'https://github.com/FredHutch/Appel887',
  force = TRUE,
  lib = datapackage_path()
)

# Example using devtools::install(). Less friendly (no lib pass-thru), but still possible:

withr::with_libpaths(datapackage_path(), devtools::install())

# attach a datapackage from "safe" library path

library(Appel887, lib.loc = datapackage_path())

# Load pdata using new lib.loc argument for visc_load_pdata()

visc_load_pdata(
  Caskey920_nab,
  "datapackage",
  "34b189faa034f29dbb0692d4676ab56f",
  lib.loc = datapackage_path()
)

sessionInfo()

```

## Related Issues

https://github.com/FredHutch/VISCtemplates/issues/307

## Checklist

- [ ] This PR includes unit tests
- [x] This PR establishes a new function or updates parameters in an existing function
  - [x]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
