### PR TITLE
Longtable page number fix for pkg reproducibility table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ Improvements for users
 * Default behavior of `create_visc_project()` no longer includes creation of package-specific files DESCRIPTION and NAMESPACE (#306)
 * Add option to drop SCHARP logo in PDF output (#312)
 * Add `visc_load_pdata()` examples to report template skeleton (#327)
-* Reproducibility table formatting changes to coordinate with recent VISCfunctions update that lengthens reproducibility packages table to include packages that are loaded but not attached (#329)
+* Reproducibility table formatting changes to coordinate with recent VISCfunctions update that lengthens reproducibility packages table to include packages that are loaded but not attached (#329, #332)
 
 Improvements for package contributors and maintainers
 

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -168,9 +168,14 @@ if (output_type == 'latex') {
   
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
-    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>%
-    kable_styling(latex_options = 'repeat_header')
-  
+    kable(
+      booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE
+    ) %>%
+    kable_styling(
+      latex_options = 'repeat_header',
+      repeat_header_method = 'replace'
+    )
+
 } else {
   
   # format nicely for Word with flextable

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -444,19 +444,24 @@ if (output_type == 'latex') {
 tbl_caption <- "Package reproducibility information"
 
 if (output_type == 'latex') {
-  
+
   # format nicely for PDF with kable and kableExtra
   my_session_info$packages_table %>%
-    kable(booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE) %>%
-    kable_styling(latex_options = 'repeat_header')
-  
+    kable(
+      booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE
+    ) %>%
+    kable_styling(
+      latex_options = 'repeat_header',
+      repeat_header_method = 'replace'
+    )
+
 } else {
-  
+
   # format nicely for Word with flextable
   my_session_info$packages_table %>%
     flextable() %>%
     set_caption(tbl_caption)
-  
+
 }
 ```
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Fix for repeat headers from package reproducibility table causing page numbering like "11/10".

## Related Issues

#329
https://github.com/FredHutch/VISCfunctions/pull/132

See also:

#270
#277


## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
