### PR TITLE
Make VISCtemplates require R >= 4.1.0 and drop R 4.0.4 from CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,8 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: '4.0.4', pandoc-version: '2.11.4'}
+          - {os: ubuntu-latest,   r: '4.4.2', pandoc-version: '3.2'}
+          - {os: ubuntu-latest,   r: '4.1.0', pandoc-version: '2.11.4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -31,14 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup statsrv pandoc
-        if: ${{ matrix.config.r == '4.0.4' }}
+      - name: Setup custom pandoc version
+        if: ${{ matrix.config.pandoc-version != null }}
         uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: ${{ matrix.config.pandoc-version }}
 
-      - name: Setup default pandoc
-        if: ${{ matrix.config.r != '4.0.4' }}
+      - name: Setup default pandoc version
+        if: ${{ matrix.config.pandoc-version == null }}
         uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up tinytex
@@ -53,15 +54,15 @@ jobs:
 
       - name: Setup recent R
         uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.r != '4.0.4' }}
+        if: ${{ matrix.config.r != '4.1.0' && matrix.config.r != '4.4.2'}}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Setup R 4.0.4
+      - name: Setup older R
         uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.r == '4.0.4' }}
+        if: ${{ matrix.config.r == '4.1.0' || matrix.config.r == '4.4.2'}}
         with:
           r-version: ${{ matrix.config.r }}
           cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-19'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Authors@R:
            email = "kmacphee@fredhutch.org")
 Description: The goal of VISCtemplates is to automate project setup provide a common easy-to-understand directory structure across analyses, provide consistency across reports in the same project/protocol, and provide consistency across reports analyzing data from the same assay.
 License: GPL-3 + file LICENSE
-Depends: R (>= 3.0)
+Depends: R (>= 4.1.0)
 Imports:
     fs,
     digest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Improvements for package contributors and maintainers
 * Remove empty "examples" in template study schema to avoid minor issues (#319)
 * Run test knits in a `callr` session to isolate Rmd library calls from main R process (#320)
 * Drop dependency on `DataPackageR` (#324)
+* VISCtemplates now depends on R >= 4.1.0 (#334)
 
 # VISCtemplates 2.0.2
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Replicates https://github.com/FredHutch/VISCfunctions/pull/134 for VISCtemplates and prepares for #310. Closes #333.

## Related Issues

Provide links to any related GitHub issues.

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
