### PR TITLE
Fix syntax error in Rmd file for git installation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 Bugfixes
 
-* Add missing comma in skeleton report to separate `visc_load_pdata()` arguments (#336)
+* Add missing comma in skeleton report to separate `install_git_workaround` arguments (#336)
 
 # VISCtemplates 2.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # VISCtemplates (development version)
 
+Bugfixes
+
+* Add missing comma in skeleton report to separate `visc_load_pdata()` arguments (#336)
+
 # VISCtemplates 2.1.0
 
 Improvements for users

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -133,7 +133,7 @@ install_git_workaround(
 install_git_workaround(
   networks_path("cavd/Studies/cvd920/pdata/Caskey920.git"),
   ref = "main",
-  git = "external"
+  git = "external",
   # `force` required if you've already installed the package w/ same hash
   # (even if installed to a different directory), because
   # `remotes::install_git` checks hash before passing `lib` to install.packages


### PR DESCRIPTION
I noticed a bug due to a missing comma in the report skeleton, so small fix for that!
