### PR TITLE
Add flextable defaults to skeleton.Rmd files

### DIFF
--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -83,12 +83,16 @@ options(knitr.table.format = output_type,
         kable_styling_latex_options = c("hold_position"))
 
 # table options for flextable
-set_flextable_defaults(na_str = "", # NA's will be blank
-                       font.size = 10,
-                       theme_fun = "theme_box",
-                       table.layout = "autofit", # automatically sets column width and row height, can be overridden for individual tables with set_table_properties(layout = "fixed")
-                       fonts_ignore = TRUE,
-                       digits = 3)
+set_flextable_defaults(
+  na_str = "", # NA's will be blank
+  font.size = 10,
+  theme_fun = "theme_box",
+  # note: table.layout automatically sets column width and row height, this setting
+  # can be overridden for individual tables with set_table_properties(layout = "fixed")
+  table.layout = "autofit", 
+  fonts_ignore = TRUE,
+  digits = 3
+)
 
 # Create a ggplot theme for consistency of figures
 visc_theme <- theme_bw() + 

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -84,12 +84,16 @@ options(knitr.table.format = output_type,
         kable_styling_latex_options = c("hold_position"))
 
 # table options for flextable
-set_flextable_defaults(na_str = "", # NA's will be blank
-                       font.size = 10,
-                       theme_fun = "theme_box",
-                       table.layout = "autofit", # automatically sets column width and row height, can be overridden for individual tables with set_table_properties(layout = "fixed")
-                       fonts_ignore = TRUE,
-                       digits = 3)
+set_flextable_defaults(
+  na_str = "", # NA's will be blank
+  font.size = 10,
+  theme_fun = "theme_box",
+  # note: automatically sets column width and row height, but can be overridden
+  # for individual tables with set_table_properties(layout = "fixed")
+  table.layout = "autofit",
+  fonts_ignore = TRUE,
+  digits = 3
+)
 
 # Create a ggplot theme for consistency of figures
 visc_theme <- theme_bw() + 
@@ -256,7 +260,7 @@ Objectives can be found on ATLAS, in the study protocol, or in the SAP.
 ```{r statistical-methods, child="child-docs/statistical-methods.Rmd"}
 ```
 
-```{r response-testing, warning=FALSE}
+```{r response-testing}
 
 # example of using VISCfunctions::pairwise_test_bin for analysis
 response_results <- ICS_adata |> 
@@ -276,7 +280,7 @@ response_results <- ICS_adata |>
   ungroup()
 ```
 
-```{r magnitude-testing, warning=FALSE}
+```{r magnitude-testing}
 
 # example of using VISCfunctions::pairwise_test_cont for analysis
 magnitude_results <- ICS_adata |>
@@ -372,7 +376,8 @@ magnitude_tab <- magnitude_results |>
 
 caption_short <- "Short caption to show in List of Tables."
 
-caption <- "Long caption to show above table. Explain everything needed to understand the table here."
+caption <- paste("Long caption to show above table.",
+                 "Explain everything needed to understand the table here.")
 
 if (output_type == 'latex') {
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

I use flextable a bunch (it has nice outputs for Word documents), and we don't currently have default formatting set up in the skeleton.Rmd files like we do for kable outputs. Proposing addition these basic conventions.

Also dropping the warning=FALSE in the skeleton.Rmd files because it goes against best practices.

## Related Issues

n/a

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [ ] I have updated NEWS.md to describe the proposed changes
