### PR TITLE
longtable caption/header fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ Bugfixes
 
 * Add missing comma in skeleton report to separate `install_git_workaround` arguments (#336)
 
+Improvements for users
+
+* Improvements to longtables: caption width and notes in template about how to avoid page numbering and formatting issues (#345)
+
 # VISCtemplates 2.1.0
 
 Improvements for users

--- a/inst/templates/report_latex_template.tex
+++ b/inst/templates/report_latex_template.tex
@@ -19,6 +19,7 @@
 \usepackage{rotating} % for xtable sideways
 \usepackage{threeparttable} % provides a scheme for tables that have a structured (foot)note section, after the caption
 \usepackage{threeparttablex} % provides the functionality of the threeparttable package to tables created using the longtable package
+\setlength{\LTcapwidth}{\textwidth} % fixes longtable caption width, which is otherwise too narrow
 
 % needed for flextable to work
 \usepackage{hhline}

--- a/inst/templates/visc_empty/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_empty/skeleton/skeleton.Rmd
@@ -201,9 +201,12 @@ if (output_type == 'latex') {
     kable(
       booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE
     ) |>
+    # NOTE: the options below should be applied to ALL longtables to avoid various formatting issues, including page numbering issues caused by repeated headers
     kable_styling(
       latex_options = 'repeat_header',
-      repeat_header_method = 'replace'
+      repeat_header_method = 'replace',
+      repeat_header_text = paste(tbl_caption, "(continued)"),
+      repeat_header_continued = TRUE
     )
 
 } else {

--- a/inst/templates/visc_report/skeleton/skeleton.Rmd
+++ b/inst/templates/visc_report/skeleton/skeleton.Rmd
@@ -473,9 +473,12 @@ if (output_type == 'latex') {
     kable(
       booktabs = TRUE, linesep = "", caption = tbl_caption, longtable = TRUE
     ) |>
+    # NOTE: the options below should be applied to ALL longtables to avoid various formatting issues, including page numbering issues caused by repeated headers
     kable_styling(
       latex_options = 'repeat_header',
-      repeat_header_method = 'replace'
+      repeat_header_method = 'replace',
+      repeat_header_text = paste(tbl_caption, "(continued)"),
+      repeat_header_continued = TRUE
     )
 
 } else {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Fixes narrow caption width for longtables, and updates formatting options for example longtable (package reproducibility table) in skeleton.Rmd files

BEFORE (generic report template with extra text added to caption to illustrate how a longer caption would look):

<img width="543" height="912" alt="Screenshot 2026-06-04 at 12 25 27 PM" src="https://github.com/user-attachments/assets/54733a05-93fb-46e5-b2b9-524fca19dad7" />


AFTER: note that both the caption width and caption/header on the second page have been updated.

<img width="543" height="912" alt="Screenshot 2026-06-04 at 12 22 23 PM" src="https://github.com/user-attachments/assets/32f0d1d6-42a1-4fbb-a5e4-eaa97d14d915" />

## Related Issues

https://github.com/FredHutch/VISCtemplates/issues/267

https://github.com/FredHutch/VISCtemplates/issues/277

## Checklist

- [ ] This PR includes unit tests
- [ ] This PR establishes a new function or updates parameters in an existing function
  - [ ]  The roxygen skeleton for this function has been updated using `devtools::document`
- [x] I have updated NEWS.md to describe the proposed changes
