### PR TITLE
add reproducibility citations to visc-project-bibliography.bib

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Bugfixes
 Improvements for users
 
 * Improvements to longtables: caption width and notes in template about how to avoid page numbering and formatting issues (#345)
+* Add citations to bibliography.bib file referenced in reproducibility reports (#349)
 
 # VISCtemplates 2.1.0
 

--- a/inst/templates/visc-project-bibliography.bib
+++ b/inst/templates/visc-project-bibliography.bib
@@ -515,3 +515,16 @@
  year = {1977}
 }
 
+@article{1960Cohen,
+ title ={A Coefficient of Agreement for Nominal Scales}, 
+ author = {Jacob Cohen},
+ journal = {Educational and Psychological Measurement},
+ volume = {20},
+ number = {1},
+ pages = {37-46},
+ year = {1960},
+ doi = {10.1177/001316446002000104},
+ URL = {https://doi.org/10.1177/001316446002000104},
+ eprint = {https://doi.org/10.1177/001316446002000104}
+}
+

--- a/inst/templates/visc-project-bibliography.bib
+++ b/inst/templates/visc-project-bibliography.bib
@@ -477,4 +477,41 @@
   url = {https://www.R-project.org/}
 }
 
+@article{1989Lin,
+ ISSN = {0006341X, 15410420},
+ URL = {http://www.jstor.org/stable/2532051},
+ author = {Lawrence I-Kuei Lin},
+ journal = {Biometrics},
+ number = {1},
+ pages = {255--268},
+ publisher = {[Wiley, International Biometric Society]},
+ title = {A Concordance Correlation Coefficient to Evaluate Reproducibility},
+ urldate = {2023-10-05},
+ volume = {45},
+ year = {1989}
+}
+
+@article{1968Cohen,
+  title={Weighted kappa: Nominal scale agreement provision for scaled disagreement or partial credit.},
+  author={Jacob Cohen},
+  journal={Psychological Bulletin},
+  year={1968},
+  volume={70},
+  pages={213-220},
+  url={https://api.semanticscholar.org/CorpusID:29694079}
+}
+
+@article{1977Landis,
+ ISSN = {0006341X, 15410420},
+ URL = {http://www.jstor.org/stable/2529310},
+ author = {J. Richard Landis and Gary G. Koch},
+ journal = {Biometrics},
+ number = {1},
+ pages = {159--174},
+ publisher = {[Wiley, International Biometric Society]},
+ title = {The Measurement of Observer Agreement for Categorical Data},
+ urldate = {2023-10-24},
+ volume = {33},
+ year = {1977}
+}
 


### PR DESCRIPTION
## Description

Add three frequently used citations from reproducibility reports to the default bibliography.bib file that gets generated in a `VDCXXXAnalysis/docs` folder.

## Checklist

No unit test or documentation needed.

- [x] I have updated NEWS.md to describe the proposed changes
